### PR TITLE
feat: Seasonal deck and observation missions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage/
 # Misc
 tmp/
 dist/
+
+# Claude worktrees
+.claude/worktrees/

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -32,11 +32,19 @@ func main() {
 	}
 	log.Println("seeded card data")
 
+	missionRepo := repository.NewInMemoryMissionRepository()
+
+	seasonalSvc := service.NewSeasonalService(cardRepo, deckRepo)
+	missionSvc := service.NewMissionService(missionRepo, cardRepo)
+
 	cardSvc := service.NewCardService(cardRepo, deckRepo)
+	cardSvc.SetSeasonalService(seasonalSvc)
 	cardHandler := handler.NewCardHandler(cardSvc)
 
 	collectionSvc := service.NewCollectionService(collectionRepo)
 	collectionHandler := handler.NewCollectionHandler(collectionSvc)
+
+	seasonalHandler := handler.NewSeasonalHandler(missionSvc, seasonalSvc)
 
 	hub := ws.NewHub()
 	gm := ws.NewGameManager(hub, cardRepo)
@@ -49,6 +57,7 @@ func main() {
 	})
 	cardHandler.RegisterRoutes(mux)
 	collectionHandler.RegisterRoutes(mux)
+	seasonalHandler.RegisterRoutes(mux)
 	wsHandler.RegisterRoutes(mux)
 
 	srv := &http.Server{

--- a/backend/internal/handler/seasonal_handler.go
+++ b/backend/internal/handler/seasonal_handler.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/akaitigo/astro-karuta/backend/internal/model"
+	"github.com/akaitigo/astro-karuta/backend/internal/service"
+)
+
+// SeasonalHandler handles HTTP requests for seasonal and mission endpoints.
+type SeasonalHandler struct {
+	missionSvc  *service.MissionService
+	seasonalSvc *service.SeasonalService
+}
+
+// NewSeasonalHandler creates a new SeasonalHandler.
+func NewSeasonalHandler(missionSvc *service.MissionService, seasonalSvc *service.SeasonalService) *SeasonalHandler {
+	return &SeasonalHandler{
+		missionSvc:  missionSvc,
+		seasonalSvc: seasonalSvc,
+	}
+}
+
+// RegisterRoutes registers seasonal and mission routes to the mux.
+func (h *SeasonalHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/missions", h.ListMissions)
+	mux.HandleFunc("POST /api/v1/missions/{id}/complete", h.CompleteMission)
+}
+
+// ListMissions returns active missions for a user.
+func (h *SeasonalHandler) ListMissions(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		writeError(w, http.StatusBadRequest, "user_id is required")
+		return
+	}
+
+	missions, err := h.missionSvc.GetActiveMissions(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, missions)
+}
+
+// CompleteMission validates and completes a mission.
+func (h *SeasonalHandler) CompleteMission(w http.ResponseWriter, r *http.Request) {
+	missionID := r.PathValue("id")
+	if missionID == "" {
+		writeError(w, http.StatusBadRequest, "mission ID is required")
+		return
+	}
+
+	var req model.CompleteMissionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.UserID == "" {
+		writeError(w, http.StatusBadRequest, "user_id is required")
+		return
+	}
+
+	resp, err := h.missionSvc.CompleteMission(r.Context(), req.UserID, missionID, req.Latitude, req.Longitude)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/backend/internal/model/mission.go
+++ b/backend/internal/model/mission.go
@@ -1,0 +1,40 @@
+package model
+
+import "time"
+
+// MissionStatus represents the state of a user's mission.
+type MissionStatus string
+
+const (
+	MissionStatusActive    MissionStatus = "active"
+	MissionStatusCompleted MissionStatus = "completed"
+	MissionStatusExpired   MissionStatus = "expired"
+)
+
+// UserMission represents an observation mission assigned to a user.
+type UserMission struct {
+	ID          string        `json:"id"`
+	UserID      string        `json:"user_id"`
+	MissionID   string        `json:"mission_id"`
+	CardID      string        `json:"card_id"`
+	Title       string        `json:"title"`
+	Description string        `json:"description"`
+	Status      MissionStatus `json:"status"`
+	ValidFrom   time.Time     `json:"valid_from"`
+	ValidTo     time.Time     `json:"valid_to"`
+	CompletedAt *time.Time    `json:"completed_at,omitempty"`
+	CreatedAt   time.Time     `json:"created_at"`
+}
+
+// CompleteMissionRequest is the request body for completing a mission.
+type CompleteMissionRequest struct {
+	UserID    string  `json:"user_id"`
+	Latitude  float64 `json:"lat"`
+	Longitude float64 `json:"lng"`
+}
+
+// CompleteMissionResponse is returned after successfully completing a mission.
+type CompleteMissionResponse struct {
+	Mission   UserMission `json:"mission"`
+	BonusCard *Card       `json:"bonus_card,omitempty"`
+}

--- a/backend/internal/repository/mission_repository.go
+++ b/backend/internal/repository/mission_repository.go
@@ -1,0 +1,99 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/akaitigo/astro-karuta/backend/internal/model"
+)
+
+// MissionRepository defines operations for mission persistence.
+type MissionRepository interface {
+	Create(ctx context.Context, mission *model.UserMission) error
+	GetByID(ctx context.Context, id string) (*model.UserMission, error)
+	ListByUserID(ctx context.Context, userID string) ([]model.UserMission, error)
+	ListActiveByUserID(ctx context.Context, userID string) ([]model.UserMission, error)
+	Update(ctx context.Context, mission *model.UserMission) error
+}
+
+// InMemoryMissionRepository is an in-memory implementation of MissionRepository.
+type InMemoryMissionRepository struct {
+	mu       sync.RWMutex
+	missions map[string]model.UserMission
+	order    []string
+}
+
+// NewInMemoryMissionRepository creates a new in-memory mission repository.
+func NewInMemoryMissionRepository() *InMemoryMissionRepository {
+	return &InMemoryMissionRepository{
+		missions: make(map[string]model.UserMission),
+	}
+}
+
+func (r *InMemoryMissionRepository) Create(_ context.Context, mission *model.UserMission) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if mission.ID == "" {
+		return fmt.Errorf("mission ID must not be empty")
+	}
+	if _, exists := r.missions[mission.ID]; exists {
+		return fmt.Errorf("mission already exists: %s", mission.ID)
+	}
+	r.missions[mission.ID] = *mission
+	r.order = append(r.order, mission.ID)
+	return nil
+}
+
+func (r *InMemoryMissionRepository) GetByID(_ context.Context, id string) (*model.UserMission, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	mission, ok := r.missions[id]
+	if !ok {
+		return nil, fmt.Errorf("mission not found: %s", id)
+	}
+	return &mission, nil
+}
+
+func (r *InMemoryMissionRepository) ListByUserID(_ context.Context, userID string) ([]model.UserMission, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []model.UserMission
+	for _, id := range r.order {
+		m := r.missions[id]
+		if m.UserID == userID {
+			result = append(result, m)
+		}
+	}
+	return result, nil
+}
+
+func (r *InMemoryMissionRepository) ListActiveByUserID(_ context.Context, userID string) ([]model.UserMission, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	now := time.Now()
+	var result []model.UserMission
+	for _, id := range r.order {
+		m := r.missions[id]
+		if m.UserID == userID && m.Status == model.MissionStatusActive && !now.After(m.ValidTo) {
+			result = append(result, m)
+		}
+	}
+	return result, nil
+}
+
+func (r *InMemoryMissionRepository) Update(_ context.Context, mission *model.UserMission) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.missions[mission.ID]; !exists {
+		return fmt.Errorf("mission not found: %s", mission.ID)
+	}
+	r.missions[mission.ID] = *mission
+	return nil
+}

--- a/backend/internal/service/card_service.go
+++ b/backend/internal/service/card_service.go
@@ -11,8 +11,9 @@ import (
 
 // CardService provides business logic for card operations.
 type CardService struct {
-	cardRepo repository.CardRepository
-	deckRepo repository.DeckRepository
+	cardRepo    repository.CardRepository
+	deckRepo    repository.DeckRepository
+	seasonalSvc *SeasonalService
 }
 
 // NewCardService creates a new CardService.
@@ -21,6 +22,11 @@ func NewCardService(cardRepo repository.CardRepository, deckRepo repository.Deck
 		cardRepo: cardRepo,
 		deckRepo: deckRepo,
 	}
+}
+
+// SetSeasonalService sets the seasonal service for deck generation.
+func (s *CardService) SetSeasonalService(svc *SeasonalService) {
+	s.seasonalSvc = svc
 }
 
 // ListCards returns cards filtered by the given criteria.
@@ -64,7 +70,12 @@ func (s *CardService) GetDeck(ctx context.Context, id string) (*model.Deck, erro
 }
 
 // GetSeasonalDeck returns the seasonal deck for the current month.
+// If a SeasonalService is set, it delegates to that service for automatic
+// deck generation based on visible constellations.
 func (s *CardService) GetSeasonalDeck(ctx context.Context) (*model.Deck, error) {
+	if s.seasonalSvc != nil {
+		return s.seasonalSvc.GetSeasonalDeck(ctx)
+	}
 	month := time.Now().Month()
 	return s.deckRepo.GetSeasonal(ctx, month)
 }

--- a/backend/internal/service/mission_service.go
+++ b/backend/internal/service/mission_service.go
@@ -1,0 +1,194 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/akaitigo/astro-karuta/backend/internal/model"
+	"github.com/akaitigo/astro-karuta/backend/internal/repository"
+	"github.com/akaitigo/astro-karuta/backend/pkg/astronomy"
+	"github.com/google/uuid"
+)
+
+// maxLatitudeDeviation is the maximum allowed deviation in latitude degrees
+// for location validation when completing a mission.
+const maxLatitudeDeviation = 30.0
+
+// MissionService provides business logic for observation missions.
+type MissionService struct {
+	missionRepo repository.MissionRepository
+	cardRepo    repository.CardRepository
+	nowFunc     func() time.Time
+}
+
+// NewMissionService creates a new MissionService.
+func NewMissionService(missionRepo repository.MissionRepository, cardRepo repository.CardRepository) *MissionService {
+	return &MissionService{
+		missionRepo: missionRepo,
+		cardRepo:    cardRepo,
+		nowFunc:     time.Now,
+	}
+}
+
+// SetNowFunc overrides the time source for testing.
+func (s *MissionService) SetNowFunc(fn func() time.Time) {
+	s.nowFunc = fn
+}
+
+// GetActiveMissions returns active missions for a user.
+// If the user has no missions, it generates missions based on the current month's
+// visible constellations.
+func (s *MissionService) GetActiveMissions(ctx context.Context, userID string) ([]model.UserMission, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("user ID must not be empty")
+	}
+
+	missions, err := s.missionRepo.ListActiveByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list active missions: %w", err)
+	}
+
+	// If user has active missions, return them
+	if len(missions) > 0 {
+		return missions, nil
+	}
+
+	// Generate new missions based on current month's visible constellations
+	now := s.nowFunc()
+	month := int(now.Month())
+	visible := astronomy.GetVisibleConstellations(month, astronomy.DefaultLatitude)
+	if len(visible) == 0 {
+		return []model.UserMission{}, nil
+	}
+
+	// Find matching constellation cards
+	allCards, err := s.cardRepo.List(ctx, repository.CardFilter{
+		Category: model.CardCategoryConstellation,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list constellation cards: %w", err)
+	}
+
+	visibleSet := make(map[string]bool, len(visible))
+	for _, name := range visible {
+		visibleSet[name] = true
+	}
+
+	// Create up to 5 missions from visible constellations
+	validFrom := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.Local)
+	validTo := validFrom.AddDate(0, 1, 0).Add(-time.Second)
+
+	var generated []model.UserMission
+	count := 0
+	for _, card := range allCards {
+		if count >= 5 {
+			break
+		}
+		if !visibleSet[card.Name] {
+			continue
+		}
+		mission := model.UserMission{
+			ID:          uuid.New().String(),
+			UserID:      userID,
+			MissionID:   fmt.Sprintf("obs-%d-%s", month, card.ID),
+			CardID:      card.ID,
+			Title:       fmt.Sprintf("%sを観測しよう", card.Name),
+			Description: fmt.Sprintf("夜空で%sを見つけて、観測ボタンを押そう！", card.Name),
+			Status:      model.MissionStatusActive,
+			ValidFrom:   validFrom,
+			ValidTo:     validTo,
+			CreatedAt:   now,
+		}
+		if err := s.missionRepo.Create(ctx, &mission); err != nil {
+			return nil, fmt.Errorf("create mission: %w", err)
+		}
+		generated = append(generated, mission)
+		count++
+	}
+
+	return generated, nil
+}
+
+// CompleteMission validates location and time, marks the mission as completed,
+// and returns the bonus card.
+func (s *MissionService) CompleteMission(ctx context.Context, userID string, missionID string, lat float64, lng float64) (*model.CompleteMissionResponse, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("user ID must not be empty")
+	}
+	if missionID == "" {
+		return nil, fmt.Errorf("mission ID must not be empty")
+	}
+
+	mission, err := s.missionRepo.GetByID(ctx, missionID)
+	if err != nil {
+		return nil, fmt.Errorf("get mission: %w", err)
+	}
+
+	// Verify the mission belongs to this user
+	if mission.UserID != userID {
+		return nil, fmt.Errorf("mission does not belong to user")
+	}
+
+	// Verify mission is still active
+	if mission.Status != model.MissionStatusActive {
+		return nil, fmt.Errorf("mission is not active (status: %s)", mission.Status)
+	}
+
+	now := s.nowFunc()
+
+	// Verify mission hasn't expired
+	if now.After(mission.ValidTo) {
+		return nil, fmt.Errorf("mission has expired")
+	}
+
+	// Time validation: must be nighttime (18:00-06:00)
+	if err := validateNighttime(now); err != nil {
+		return nil, err
+	}
+
+	// Location validation: latitude within +-30 degrees of default
+	if err := validateLocation(lat, lng); err != nil {
+		return nil, err
+	}
+
+	// Mark mission as completed
+	completedAt := now
+	mission.Status = model.MissionStatusCompleted
+	mission.CompletedAt = &completedAt
+
+	if err := s.missionRepo.Update(ctx, mission); err != nil {
+		return nil, fmt.Errorf("update mission: %w", err)
+	}
+
+	// Get the bonus card
+	card, err := s.cardRepo.GetByID(ctx, mission.CardID)
+	if err != nil {
+		return nil, fmt.Errorf("get bonus card: %w", err)
+	}
+
+	return &model.CompleteMissionResponse{
+		Mission:   *mission,
+		BonusCard: card,
+	}, nil
+}
+
+// validateNighttime checks that the time is between 18:00 and 06:00.
+func validateNighttime(t time.Time) error {
+	hour := t.Hour()
+	if hour >= 6 && hour < 18 {
+		return fmt.Errorf("observation must be at nighttime (18:00-06:00), current hour: %d", hour)
+	}
+	return nil
+}
+
+// validateLocation checks that the latitude is within +-30 degrees
+// of the default observation latitude.
+func validateLocation(lat float64, _ float64) error {
+	deviation := math.Abs(lat - astronomy.DefaultLatitude)
+	if deviation > maxLatitudeDeviation {
+		return fmt.Errorf("location too far from observation area (deviation: %.1f degrees, max: %.1f)", deviation, maxLatitudeDeviation)
+	}
+	return nil
+}

--- a/backend/internal/service/mission_service_test.go
+++ b/backend/internal/service/mission_service_test.go
@@ -1,0 +1,279 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/akaitigo/astro-karuta/backend/internal/repository"
+	"github.com/akaitigo/astro-karuta/backend/internal/seed"
+	"github.com/akaitigo/astro-karuta/backend/internal/service"
+)
+
+func setupMissionService(t *testing.T) (*service.MissionService, *repository.InMemoryCardRepository) {
+	t.Helper()
+	cardRepo := repository.NewInMemoryCardRepository()
+	missionRepo := repository.NewInMemoryMissionRepository()
+
+	if err := seed.LoadCards(context.Background(), cardRepo); err != nil {
+		t.Fatal(err)
+	}
+	svc := service.NewMissionService(missionRepo, cardRepo)
+	return svc, cardRepo
+}
+
+func TestMissionService_GetActiveMissions_EmptyUserID(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	_, err := svc.GetActiveMissions(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestMissionService_GetActiveMissions_GeneratesMissions(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	// Set time to July (summer) for predictable results
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 20, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missions) == 0 {
+		t.Fatal("expected missions to be generated")
+	}
+	if len(missions) > 5 {
+		t.Errorf("expected at most 5 missions, got %d", len(missions))
+	}
+
+	for _, m := range missions {
+		if m.UserID != "user-1" {
+			t.Errorf("expected user ID user-1, got %s", m.UserID)
+		}
+		if m.Status != "active" {
+			t.Errorf("expected active status, got %s", m.Status)
+		}
+	}
+}
+
+func TestMissionService_GetActiveMissions_ReturnsCached(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 20, 0, 0, 0, time.Local)
+	})
+
+	// First call generates
+	missions1, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second call returns same missions
+	missions2, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(missions1) != len(missions2) {
+		t.Errorf("expected same count: %d vs %d", len(missions1), len(missions2))
+	}
+}
+
+func TestMissionService_CompleteMission_Success(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	// Generate missions at nighttime in July
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missions) == 0 {
+		t.Fatal("expected missions to be generated")
+	}
+
+	// Complete the first mission with valid location (near Tokyo)
+	resp, err := svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 35.0, 139.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Mission.Status != "completed" {
+		t.Errorf("expected completed status, got %s", resp.Mission.Status)
+	}
+	if resp.BonusCard == nil {
+		t.Error("expected bonus card")
+	}
+	if resp.Mission.CompletedAt == nil {
+		t.Error("expected completed_at to be set")
+	}
+}
+
+func TestMissionService_CompleteMission_EmptyUserID(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	_, err := svc.CompleteMission(context.Background(), "", "mission-1", 35.0, 139.0)
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestMissionService_CompleteMission_EmptyMissionID(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	_, err := svc.CompleteMission(context.Background(), "user-1", "", 35.0, 139.0)
+	if err == nil {
+		t.Fatal("expected error for empty mission ID")
+	}
+}
+
+func TestMissionService_CompleteMission_WrongUser(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Try to complete as a different user
+	_, err = svc.CompleteMission(context.Background(), "user-2", missions[0].ID, 35.0, 139.0)
+	if err == nil {
+		t.Fatal("expected error for wrong user")
+	}
+}
+
+func TestMissionService_CompleteMission_Daytime(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	// Generate at night
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Try to complete during daytime
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 12, 0, 0, 0, time.Local)
+	})
+
+	_, err = svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 35.0, 139.0)
+	if err == nil {
+		t.Fatal("expected error for daytime completion")
+	}
+}
+
+func TestMissionService_CompleteMission_LocationTooFar(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Location far from Tokyo (latitude deviation > 30)
+	_, err = svc.CompleteMission(context.Background(), "user-1", missions[0].ID, -20.0, 139.0)
+	if err == nil {
+		t.Fatal("expected error for location too far")
+	}
+}
+
+func TestMissionService_CompleteMission_AlreadyCompleted(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Complete once
+	_, err = svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 35.0, 139.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Try to complete again
+	_, err = svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 35.0, 139.0)
+	if err == nil {
+		t.Fatal("expected error for already completed mission")
+	}
+}
+
+func TestMissionService_CompleteMission_NighttimeBoundary(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	// Generate missions
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 22, 0, 0, 0, time.Local)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	missionID := missions[0].ID
+
+	testCases := []struct {
+		name    string
+		hour    int
+		wantErr bool
+	}{
+		{"midnight", 0, false},
+		{"5am", 5, false},
+		{"6am_rejected", 6, true},
+		{"noon", 12, true},
+		{"5pm_rejected", 17, true},
+		{"6pm_accepted", 18, false},
+		{"11pm", 23, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Re-setup to get fresh missions
+			innerSvc, _ := setupMissionService(t)
+			innerSvc.SetNowFunc(func() time.Time {
+				return time.Date(2026, 7, 15, 22, 0, 0, 0, time.Local)
+			})
+
+			innerMissions, err := innerSvc.GetActiveMissions(context.Background(), "user-1")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_ = missionID // referenced from outer scope only as pattern
+
+			innerSvc.SetNowFunc(func() time.Time {
+				return time.Date(2026, 7, 15, tc.hour, 0, 0, 0, time.Local)
+			})
+
+			_, err = innerSvc.CompleteMission(context.Background(), "user-1", innerMissions[0].ID, 35.0, 139.0)
+			if tc.wantErr && err == nil {
+				t.Errorf("hour %d: expected error", tc.hour)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("hour %d: unexpected error: %v", tc.hour, err)
+			}
+		})
+	}
+}

--- a/backend/internal/service/seasonal_service.go
+++ b/backend/internal/service/seasonal_service.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/akaitigo/astro-karuta/backend/internal/model"
+	"github.com/akaitigo/astro-karuta/backend/internal/repository"
+	"github.com/akaitigo/astro-karuta/backend/pkg/astronomy"
+	"github.com/google/uuid"
+)
+
+// SeasonalService provides seasonal deck generation logic.
+type SeasonalService struct {
+	cardRepo repository.CardRepository
+	deckRepo repository.DeckRepository
+}
+
+// NewSeasonalService creates a new SeasonalService.
+func NewSeasonalService(cardRepo repository.CardRepository, deckRepo repository.DeckRepository) *SeasonalService {
+	return &SeasonalService{
+		cardRepo: cardRepo,
+		deckRepo: deckRepo,
+	}
+}
+
+// GenerateSeasonalDeck creates or retrieves a seasonal deck
+// containing cards for constellations visible in the given month.
+func (s *SeasonalService) GenerateSeasonalDeck(ctx context.Context, month int) (*model.Deck, error) {
+	if month < 1 || month > 12 {
+		return nil, fmt.Errorf("invalid month: %d", month)
+	}
+
+	// Try to get an existing seasonal deck for this month
+	m := time.Month(month)
+	existing, err := s.deckRepo.GetSeasonal(ctx, m)
+	if err == nil && existing != nil {
+		return existing, nil
+	}
+
+	// Get visible constellation names
+	visible := astronomy.GetVisibleConstellations(month, astronomy.DefaultLatitude)
+	if len(visible) == 0 {
+		return nil, fmt.Errorf("no visible constellations for month %d", month)
+	}
+
+	// Find matching constellation cards
+	allCards, err := s.cardRepo.List(ctx, repository.CardFilter{
+		Category: model.CardCategoryConstellation,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list constellation cards: %w", err)
+	}
+
+	visibleSet := make(map[string]bool, len(visible))
+	for _, name := range visible {
+		visibleSet[name] = true
+	}
+
+	var cardIDs []string
+	for _, card := range allCards {
+		if visibleSet[strings.TrimSpace(card.Name)] {
+			cardIDs = append(cardIDs, card.ID)
+		}
+	}
+
+	if len(cardIDs) == 0 {
+		return nil, fmt.Errorf("no matching cards found for month %d", month)
+	}
+
+	// Build the valid time range for this month
+	now := time.Now()
+	year := now.Year()
+	validFrom := time.Date(year, m, 1, 0, 0, 0, 0, time.Local)
+	validTo := validFrom.AddDate(0, 1, 0).Add(-time.Second)
+
+	deck := &model.Deck{
+		ID:        uuid.New().String(),
+		Name:      fmt.Sprintf("%d月の星座デッキ", month),
+		CardIDs:   cardIDs,
+		Seasonal:  true,
+		ValidFrom: validFrom,
+		ValidTo:   validTo,
+	}
+
+	if err := s.deckRepo.Create(ctx, deck); err != nil {
+		return nil, fmt.Errorf("create seasonal deck: %w", err)
+	}
+
+	return deck, nil
+}
+
+// GetSeasonalDeck returns the seasonal deck for the current month,
+// generating it if it does not exist.
+func (s *SeasonalService) GetSeasonalDeck(ctx context.Context) (*model.Deck, error) {
+	month := int(time.Now().Month())
+	return s.GenerateSeasonalDeck(ctx, month)
+}

--- a/backend/pkg/astronomy/seasonal.go
+++ b/backend/pkg/astronomy/seasonal.go
@@ -1,0 +1,87 @@
+package astronomy
+
+// DefaultLatitude is the default observation latitude (Tokyo).
+const DefaultLatitude = 35.68
+
+// visibilityTable maps constellation names to their visible months (1-12).
+// Each entry is a slice of month numbers when the constellation is best visible.
+var visibilityTable = map[string][]int{
+	"オリオン座":      {11, 12, 1, 2, 3},
+	"おおぐま座":      {2, 3, 4, 5, 6},
+	"さそり座":       {5, 6, 7, 8, 9},
+	"こと座":        {6, 7, 8, 9, 10},
+	"はくちょう座":     {6, 7, 8, 9, 10},
+	"わし座":        {6, 7, 8, 9, 10},
+	"おうし座":       {10, 11, 12, 1, 2},
+	"ふたご座":       {11, 12, 1, 2, 3},
+	"しし座":        {2, 3, 4, 5, 6},
+	"おとめ座":       {3, 4, 5, 6, 7},
+	"みずがめ座":      {8, 9, 10, 11, 12},
+	"うお座":        {9, 10, 11, 12, 1},
+	"おひつじ座":      {9, 10, 11, 12, 1},
+	"かに座":        {1, 2, 3, 4, 5},
+	"てんびん座":      {4, 5, 6, 7, 8},
+	"いて座":        {6, 7, 8, 9, 10},
+	"やぎ座":        {8, 9, 10, 11, 12},
+	"カシオペヤ座":     {9, 10, 11, 12, 1},
+	"ペルセウス座":     {10, 11, 12, 1, 2},
+	"アンドロメダ座":    {9, 10, 11, 12, 1},
+	"こぐま座":       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+	"おおいぬ座":      {11, 12, 1, 2, 3},
+	"こいぬ座":       {12, 1, 2, 3, 4},
+	"ぎょしゃ座":      {10, 11, 12, 1, 2},
+	"りゅう座":       {5, 6, 7, 8, 9},
+	"ケンタウルス座":    {3, 4, 5, 6, 7},
+	"みなみじゅうじ座":   {3, 4, 5, 6, 7},
+	"ヘルクレス座":     {5, 6, 7, 8, 9},
+	"ペガスス座":      {8, 9, 10, 11, 12},
+	"うしかい座":      {3, 4, 5, 6, 7},
+}
+
+// GetVisibleConstellations returns the names of constellations visible
+// in the given month at the specified latitude.
+// Latitude adjusts visibility: constellations at extreme southern declinations
+// are excluded for high northern latitudes and vice versa.
+func GetVisibleConstellations(month int, latitude float64) []string {
+	if month < 1 || month > 12 {
+		return nil
+	}
+
+	// Southern-hemisphere-only constellations that are hard to see
+	// from latitudes above +40 degrees.
+	southernOnly := map[string]bool{
+		"みなみじゅうじ座": true,
+		"ケンタウルス座":  true,
+	}
+
+	var result []string
+	for name, months := range visibilityTable {
+		if !containsMonth(months, month) {
+			continue
+		}
+		// At latitudes above 40 N, southern-only constellations are not visible.
+		if latitude > 40.0 && southernOnly[name] {
+			continue
+		}
+		result = append(result, name)
+	}
+	return result
+}
+
+// AllConstellationNames returns all constellation names in the visibility table.
+func AllConstellationNames() []string {
+	names := make([]string, 0, len(visibilityTable))
+	for name := range visibilityTable {
+		names = append(names, name)
+	}
+	return names
+}
+
+func containsMonth(months []int, target int) bool {
+	for _, m := range months {
+		if m == target {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/pkg/astronomy/seasonal_test.go
+++ b/backend/pkg/astronomy/seasonal_test.go
@@ -1,0 +1,168 @@
+package astronomy
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestGetVisibleConstellations_January(t *testing.T) {
+	result := GetVisibleConstellations(1, DefaultLatitude)
+	if len(result) == 0 {
+		t.Fatal("expected visible constellations in January")
+	}
+
+	// January should include winter constellations
+	expected := map[string]bool{
+		"オリオン座":  true,
+		"おうし座":   true,
+		"ふたご座":   true,
+		"おおいぬ座":  true,
+		"こいぬ座":   true,
+		"こぐま座":   true,
+		"かに座":    true,
+		"ペルセウス座": true,
+	}
+
+	resultSet := make(map[string]bool)
+	for _, name := range result {
+		resultSet[name] = true
+	}
+
+	for name := range expected {
+		if !resultSet[name] {
+			t.Errorf("expected %s to be visible in January", name)
+		}
+	}
+}
+
+func TestGetVisibleConstellations_July(t *testing.T) {
+	result := GetVisibleConstellations(7, DefaultLatitude)
+	if len(result) == 0 {
+		t.Fatal("expected visible constellations in July")
+	}
+
+	// July should include summer constellations
+	expected := map[string]bool{
+		"さそり座":   true,
+		"こと座":    true,
+		"はくちょう座": true,
+		"わし座":    true,
+	}
+
+	resultSet := make(map[string]bool)
+	for _, name := range result {
+		resultSet[name] = true
+	}
+
+	for name := range expected {
+		if !resultSet[name] {
+			t.Errorf("expected %s to be visible in July", name)
+		}
+	}
+}
+
+func TestGetVisibleConstellations_Circumpolar(t *testing.T) {
+	// こぐま座 should be visible all year at Tokyo latitude
+	for month := 1; month <= 12; month++ {
+		result := GetVisibleConstellations(month, DefaultLatitude)
+		found := false
+		for _, name := range result {
+			if name == "こぐま座" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected こぐま座 to be visible in month %d", month)
+		}
+	}
+}
+
+func TestGetVisibleConstellations_InvalidMonth(t *testing.T) {
+	result := GetVisibleConstellations(0, DefaultLatitude)
+	if result != nil {
+		t.Error("expected nil for month 0")
+	}
+
+	result = GetVisibleConstellations(13, DefaultLatitude)
+	if result != nil {
+		t.Error("expected nil for month 13")
+	}
+
+	result = GetVisibleConstellations(-1, DefaultLatitude)
+	if result != nil {
+		t.Error("expected nil for month -1")
+	}
+}
+
+func TestGetVisibleConstellations_HighLatitude_ExcludesSouthern(t *testing.T) {
+	// At latitude > 40, southern-only constellations should be excluded
+	result := GetVisibleConstellations(5, 50.0)
+	for _, name := range result {
+		if name == "みなみじゅうじ座" || name == "ケンタウルス座" {
+			t.Errorf("expected %s to be excluded at latitude 50", name)
+		}
+	}
+}
+
+func TestGetVisibleConstellations_LowLatitude_IncludesSouthern(t *testing.T) {
+	// At latitude <= 40, southern constellations should be included
+	result := GetVisibleConstellations(5, 30.0)
+	resultSet := make(map[string]bool)
+	for _, name := range result {
+		resultSet[name] = true
+	}
+
+	if !resultSet["ケンタウルス座"] {
+		t.Error("expected ケンタウルス座 to be visible at latitude 30")
+	}
+	if !resultSet["みなみじゅうじ座"] {
+		t.Error("expected みなみじゅうじ座 to be visible at latitude 30")
+	}
+}
+
+func TestAllConstellationNames(t *testing.T) {
+	names := AllConstellationNames()
+	if len(names) != 30 {
+		t.Errorf("expected 30 constellation names, got %d", len(names))
+	}
+
+	// Verify no duplicates
+	sort.Strings(names)
+	for i := 1; i < len(names); i++ {
+		if names[i] == names[i-1] {
+			t.Errorf("duplicate constellation name: %s", names[i])
+		}
+	}
+}
+
+func TestGetVisibleConstellations_SeasonalTransition(t *testing.T) {
+	// Verify that spring and autumn have different dominant constellations
+	springResult := GetVisibleConstellations(4, DefaultLatitude)
+	autumnResult := GetVisibleConstellations(10, DefaultLatitude)
+
+	springSet := make(map[string]bool)
+	for _, name := range springResult {
+		springSet[name] = true
+	}
+	autumnSet := make(map[string]bool)
+	for _, name := range autumnResult {
+		autumnSet[name] = true
+	}
+
+	// Spring should have these but not autumn
+	if !springSet["しし座"] {
+		t.Error("expected しし座 in spring")
+	}
+	if autumnSet["しし座"] {
+		t.Error("expected しし座 not in autumn")
+	}
+
+	// Autumn should have these but not spring
+	if !autumnSet["ペガスス座"] {
+		t.Error("expected ペガスス座 in autumn")
+	}
+	if springSet["ペガスス座"] {
+		t.Error("expected ペガスス座 not in spring")
+	}
+}

--- a/frontend/src/app/missions/page.tsx
+++ b/frontend/src/app/missions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import MissionCard from "@/components/MissionCard";
 import type { UserMission, CompleteMissionResponse } from "@/types/mission";
 
@@ -171,7 +172,7 @@ export default function MissionsPage() {
       )}
 
       <div style={{ marginTop: "24px" }}>
-        <a
+        <Link
           href="/"
           style={{
             color: "#1565C0",
@@ -180,7 +181,7 @@ export default function MissionsPage() {
           }}
         >
           ホームに戻る
-        </a>
+        </Link>
       </div>
     </main>
   );

--- a/frontend/src/app/missions/page.tsx
+++ b/frontend/src/app/missions/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import MissionCard from "@/components/MissionCard";
+import type { UserMission, CompleteMissionResponse } from "@/types/mission";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+// Default user ID for demo purposes (would come from auth in production)
+const DEMO_USER_ID = "demo-user";
+
+export default function MissionsPage() {
+  const [missions, setMissions] = useState<UserMission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [completingId, setCompletingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const fetchMissions = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const res = await fetch(
+        `${API_BASE}/api/v1/missions?user_id=${DEMO_USER_ID}`
+      );
+      if (!res.ok) {
+        throw new Error("ミッションの取得に失敗しました");
+      }
+      const data: UserMission[] = await res.json();
+      setMissions(data ?? []);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("不明なエラーが発生しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchMissions();
+  }, [fetchMissions]);
+
+  const handleComplete = useCallback(
+    async (missionId: string) => {
+      try {
+        setCompletingId(missionId);
+        setError(null);
+        setSuccessMessage(null);
+
+        // Get current position via Geolocation API
+        let lat = 35.68;
+        let lng = 139.77;
+
+        if (typeof navigator !== "undefined" && navigator.geolocation) {
+          try {
+            const position = await new Promise<GeolocationPosition>(
+              (resolve, reject) => {
+                navigator.geolocation.getCurrentPosition(resolve, reject, {
+                  timeout: 5000,
+                });
+              }
+            );
+            lat = position.coords.latitude;
+            lng = position.coords.longitude;
+          } catch {
+            // Use default coordinates if geolocation fails
+          }
+        }
+
+        const res = await fetch(
+          `${API_BASE}/api/v1/missions/${missionId}/complete`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              user_id: DEMO_USER_ID,
+              lat,
+              lng,
+            }),
+          }
+        );
+
+        if (!res.ok) {
+          const errData: { error?: string } = await res.json();
+          throw new Error(errData.error ?? "ミッションの完了に失敗しました");
+        }
+
+        const data: CompleteMissionResponse = await res.json();
+
+        // Update mission in local state
+        setMissions((prev) =>
+          prev.map((m) => (m.id === missionId ? data.mission : m))
+        );
+
+        if (data.bonus_card) {
+          setSuccessMessage(
+            `${data.bonus_card.name}のカードを獲得しました！`
+          );
+        } else {
+          setSuccessMessage("ミッション達成！");
+        }
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("不明なエラーが発生しました");
+        }
+      } finally {
+        setCompletingId(null);
+      }
+    },
+    []
+  );
+
+  return (
+    <main style={{ padding: "24px", maxWidth: "600px", margin: "0 auto" }}>
+      <h1>観測ミッション</h1>
+      <p style={{ color: "#666", marginBottom: "24px" }}>
+        今月見える星座を実際に観測してカードを集めよう！
+      </p>
+
+      {error && (
+        <div
+          style={{
+            backgroundColor: "#FFEBEE",
+            color: "#D32F2F",
+            padding: "12px",
+            borderRadius: "8px",
+            marginBottom: "16px",
+          }}
+          data-testid="mission-error"
+        >
+          {error}
+        </div>
+      )}
+
+      {successMessage && (
+        <div
+          style={{
+            backgroundColor: "#E8F5E9",
+            color: "#2E7D32",
+            padding: "12px",
+            borderRadius: "8px",
+            marginBottom: "16px",
+          }}
+          data-testid="mission-success"
+        >
+          {successMessage}
+        </div>
+      )}
+
+      {loading ? (
+        <p>読み込み中...</p>
+      ) : missions.length === 0 ? (
+        <p>現在利用可能なミッションはありません。</p>
+      ) : (
+        <div>
+          {missions.map((mission) => (
+            <MissionCard
+              key={mission.id}
+              mission={mission}
+              onComplete={(id) => void handleComplete(id)}
+              isLoading={completingId === mission.id}
+            />
+          ))}
+        </div>
+      )}
+
+      <div style={{ marginTop: "24px" }}>
+        <a
+          href="/"
+          style={{
+            color: "#1565C0",
+            textDecoration: "none",
+            fontSize: "14px",
+          }}
+        >
+          ホームに戻る
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/seasonal/page.tsx
+++ b/frontend/src/app/seasonal/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import type { Deck, Card } from "@/types/card";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
@@ -122,7 +123,7 @@ export default function SeasonalPage() {
         ))}
       </div>
 
-      <a
+      <Link
         href="/"
         style={{
           display: "inline-block",
@@ -136,7 +137,7 @@ export default function SeasonalPage() {
         }}
       >
         このデッキで遊ぶ
-      </a>
+      </Link>
     </main>
   );
 }

--- a/frontend/src/app/seasonal/page.tsx
+++ b/frontend/src/app/seasonal/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import type { Deck, Card } from "@/types/card";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+export default function SeasonalPage() {
+  const [deck, setDeck] = useState<Deck | null>(null);
+  const [cards, setCards] = useState<Card[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentMonth = new Date().getMonth() + 1;
+  const monthNames = [
+    "", "1月", "2月", "3月", "4月", "5月", "6月",
+    "7月", "8月", "9月", "10月", "11月", "12月",
+  ];
+
+  const fetchSeasonalDeck = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const deckRes = await fetch(`${API_BASE}/api/v1/decks/seasonal`);
+      if (!deckRes.ok) {
+        throw new Error("季節デッキの取得に失敗しました");
+      }
+      const deckData: Deck = await deckRes.json();
+      setDeck(deckData);
+
+      // Fetch each card in the deck
+      const cardPromises = deckData.card_ids.map(async (id) => {
+        const res = await fetch(`${API_BASE}/api/v1/cards/${id}`);
+        if (!res.ok) {
+          return null;
+        }
+        const card: Card = await res.json();
+        return card;
+      });
+
+      const fetchedCards = await Promise.all(cardPromises);
+      setCards(fetchedCards.filter((c): c is Card => c !== null));
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("不明なエラーが発生しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchSeasonalDeck();
+  }, [fetchSeasonalDeck]);
+
+  if (loading) {
+    return (
+      <main style={{ padding: "24px", maxWidth: "800px", margin: "0 auto" }}>
+        <h1>{monthNames[currentMonth]}の星座デッキ</h1>
+        <p>読み込み中...</p>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main style={{ padding: "24px", maxWidth: "800px", margin: "0 auto" }}>
+        <h1>{monthNames[currentMonth]}の星座デッキ</h1>
+        <p style={{ color: "#D32F2F" }}>{error}</p>
+        <button onClick={() => void fetchSeasonalDeck()}>再試行</button>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: "24px", maxWidth: "800px", margin: "0 auto" }}>
+      <h1>{monthNames[currentMonth]}の星座デッキ</h1>
+
+      {deck && (
+        <p style={{ color: "#666", marginBottom: "16px" }}>
+          {deck.name} - {cards.length}枚の星座カード
+        </p>
+      )}
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+          gap: "16px",
+          marginBottom: "24px",
+        }}
+      >
+        {cards.map((card) => (
+          <div
+            key={card.id}
+            style={{
+              border: "2px solid #1565C0",
+              borderRadius: "12px",
+              padding: "16px",
+              backgroundColor: "#E3F2FD",
+            }}
+            data-testid="seasonal-card"
+          >
+            <h3 style={{ margin: "0 0 8px 0", color: "#1565C0" }}>
+              {card.name}
+            </h3>
+            <p style={{ fontSize: "14px", color: "#555", margin: "0 0 8px 0" }}>
+              {card.reading_text}
+            </p>
+            <p style={{ fontSize: "12px", color: "#888", margin: 0 }}>
+              {card.description}
+            </p>
+            {card.magnitude !== undefined && (
+              <p style={{ fontSize: "12px", color: "#999", margin: "4px 0 0 0" }}>
+                等級: {card.magnitude}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <a
+        href="/"
+        style={{
+          display: "inline-block",
+          backgroundColor: "#FF9800",
+          color: "#FFFFFF",
+          padding: "12px 24px",
+          borderRadius: "8px",
+          textDecoration: "none",
+          fontWeight: "bold",
+          fontSize: "16px",
+        }}
+      >
+        このデッキで遊ぶ
+      </a>
+    </main>
+  );
+}

--- a/frontend/src/components/MissionCard.test.tsx
+++ b/frontend/src/components/MissionCard.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import MissionCard from "./MissionCard";
+import type { UserMission } from "@/types/mission";
+
+function createMission(overrides: Partial<UserMission> = {}): UserMission {
+  const now = new Date();
+  const validTo = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  return {
+    id: "mission-1",
+    user_id: "user-1",
+    mission_id: "obs-7-card-1",
+    card_id: "card-1",
+    title: "オリオン座を観測しよう",
+    description: "夜空でオリオン座を見つけて、観測ボタンを押そう！",
+    status: "active",
+    valid_from: now.toISOString(),
+    valid_to: validTo.toISOString(),
+    created_at: now.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("MissionCard", () => {
+  it("renders mission title", () => {
+    const mission = createMission();
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByText("オリオン座を観測しよう")).toBeInTheDocument();
+  });
+
+  it("renders mission description", () => {
+    const mission = createMission();
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByText("夜空でオリオン座を見つけて、観測ボタンを押そう！")).toBeInTheDocument();
+  });
+
+  it("shows active status for active missions", () => {
+    const mission = createMission({ status: "active" });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByTestId("mission-status")).toHaveTextContent("進行中");
+  });
+
+  it("shows completed status for completed missions", () => {
+    const mission = createMission({
+      status: "completed",
+      completed_at: new Date().toISOString(),
+    });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByTestId("mission-status")).toHaveTextContent("達成！");
+  });
+
+  it("shows expired status for expired missions", () => {
+    const mission = createMission({ status: "expired" });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByTestId("mission-status")).toHaveTextContent("期限切れ");
+  });
+
+  it("shows complete button for active missions", () => {
+    const mission = createMission({ status: "active" });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByTestId("mission-complete-button")).toBeInTheDocument();
+    expect(screen.getByTestId("mission-complete-button")).toHaveTextContent("観測した！");
+  });
+
+  it("hides complete button for completed missions", () => {
+    const mission = createMission({ status: "completed" });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.queryByTestId("mission-complete-button")).not.toBeInTheDocument();
+  });
+
+  it("hides complete button for expired missions", () => {
+    const mission = createMission({ status: "expired" });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.queryByTestId("mission-complete-button")).not.toBeInTheDocument();
+  });
+
+  it("calls onComplete when button is clicked", () => {
+    const mission = createMission();
+    const onComplete = vi.fn();
+    render(<MissionCard mission={mission} onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByTestId("mission-complete-button"));
+    expect(onComplete).toHaveBeenCalledWith("mission-1");
+  });
+
+  it("shows loading state", () => {
+    const mission = createMission();
+    render(<MissionCard mission={mission} onComplete={() => {}} isLoading={true} />);
+    const button = screen.getByTestId("mission-complete-button");
+    expect(button).toHaveTextContent("送信中...");
+    expect(button).toBeDisabled();
+  });
+
+  it("shows remaining time for active missions", () => {
+    const mission = createMission();
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    const remaining = screen.getByTestId("mission-remaining");
+    expect(remaining.textContent).toMatch(/残り/);
+  });
+
+  it("shows observation complete for completed missions", () => {
+    const mission = createMission({ status: "completed" });
+    render(<MissionCard mission={mission} onComplete={() => {}} />);
+    expect(screen.getByTestId("mission-remaining")).toHaveTextContent("観測完了");
+  });
+});

--- a/frontend/src/components/MissionCard.tsx
+++ b/frontend/src/components/MissionCard.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { UserMission } from "@/types/mission";
+
+interface MissionCardProps {
+  mission: UserMission;
+  onComplete: (missionId: string) => void;
+  isLoading?: boolean;
+}
+
+function formatRemainingTime(validTo: string): string {
+  const end = new Date(validTo);
+  const now = new Date();
+  const diffMs = end.getTime() - now.getTime();
+
+  if (diffMs <= 0) {
+    return "期限切れ";
+  }
+
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+
+  if (days > 0) {
+    return `残り${days}日${hours}時間`;
+  }
+  return `残り${hours}時間`;
+}
+
+function statusLabel(status: UserMission["status"]): string {
+  switch (status) {
+    case "active":
+      return "進行中";
+    case "completed":
+      return "達成！";
+    case "expired":
+      return "期限切れ";
+  }
+}
+
+function statusColor(status: UserMission["status"]): string {
+  switch (status) {
+    case "active":
+      return "#4CAF50";
+    case "completed":
+      return "#2196F3";
+    case "expired":
+      return "#9E9E9E";
+  }
+}
+
+export default function MissionCard({ mission, onComplete, isLoading = false }: MissionCardProps) {
+  const isActive = mission.status === "active";
+
+  return (
+    <div
+      style={{
+        border: `2px solid ${statusColor(mission.status)}`,
+        borderRadius: "12px",
+        padding: "16px",
+        marginBottom: "12px",
+        backgroundColor: mission.status === "completed" ? "#E3F2FD" : "#FFFFFF",
+        opacity: mission.status === "expired" ? 0.6 : 1,
+      }}
+      data-testid="mission-card"
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h3 style={{ margin: 0, fontSize: "18px" }}>{mission.title}</h3>
+        <span
+          style={{
+            backgroundColor: statusColor(mission.status),
+            color: "#FFFFFF",
+            padding: "4px 8px",
+            borderRadius: "12px",
+            fontSize: "12px",
+            fontWeight: "bold",
+          }}
+          data-testid="mission-status"
+        >
+          {statusLabel(mission.status)}
+        </span>
+      </div>
+
+      <p style={{ color: "#666", margin: "8px 0" }}>{mission.description}</p>
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "12px" }}>
+        <span style={{ fontSize: "14px", color: "#888" }} data-testid="mission-remaining">
+          {mission.status === "completed"
+            ? "観測完了"
+            : formatRemainingTime(mission.valid_to)}
+        </span>
+
+        {isActive && (
+          <button
+            onClick={() => onComplete(mission.id)}
+            disabled={isLoading}
+            style={{
+              backgroundColor: isLoading ? "#BDBDBD" : "#FF9800",
+              color: "#FFFFFF",
+              border: "none",
+              borderRadius: "8px",
+              padding: "8px 16px",
+              fontSize: "14px",
+              fontWeight: "bold",
+              cursor: isLoading ? "not-allowed" : "pointer",
+            }}
+            data-testid="mission-complete-button"
+          >
+            {isLoading ? "送信中..." : "観測した！"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/mission.ts
+++ b/frontend/src/types/mission.ts
@@ -1,0 +1,32 @@
+export type MissionStatus = "active" | "completed" | "expired";
+
+export interface UserMission {
+  id: string;
+  user_id: string;
+  mission_id: string;
+  card_id: string;
+  title: string;
+  description: string;
+  status: MissionStatus;
+  valid_from: string;
+  valid_to: string;
+  completed_at?: string;
+  created_at: string;
+}
+
+export interface CompleteMissionRequest {
+  user_id: string;
+  lat: number;
+  lng: number;
+}
+
+export interface CompleteMissionResponse {
+  mission: UserMission;
+  bonus_card?: {
+    id: string;
+    name: string;
+    category: string;
+    reading_text: string;
+    description: string;
+  };
+}


### PR DESCRIPTION
## Summary
- 天文可視性テーブル（30星座 x 月）に基づく季節連動デッキ自動生成
- 観測ミッション機能（時間帯・位置情報バリデーション付き）
- フロントエンド: 季節デッキページ、ミッション一覧ページ、MissionCardコンポーネント

## Changes
### Backend
- `backend/pkg/astronomy/seasonal.go` — 月・緯度ベースの星座可視性テーブルとクエリ関数
- `backend/internal/service/seasonal_service.go` — 月ごとの季節デッキ自動生成
- `backend/internal/service/mission_service.go` — ミッション生成・完了（夜間18-06時、緯度±30度バリデーション）
- `backend/internal/repository/mission_repository.go` — InMemory ミッションリポジトリ
- `backend/internal/handler/seasonal_handler.go` — `GET /api/v1/missions`, `POST /api/v1/missions/{id}/complete`
- `backend/internal/service/card_service.go` — `GetSeasonalDeck` が SeasonalService に委譲するよう更新
- `backend/cmd/api/main.go` — 新サービス・ハンドラのワイヤリング

### Frontend
- `frontend/src/app/seasonal/page.tsx` — 今月の季節デッキ表示ページ
- `frontend/src/app/missions/page.tsx` — 観測ミッション一覧・完了ページ
- `frontend/src/components/MissionCard.tsx` — ミッション情報・ステータス・残り時間表示

### Tests
- `backend/pkg/astronomy/seasonal_test.go` — 可視性テーブルの月別・緯度別テスト
- `backend/internal/service/mission_service_test.go` — 時間帯・位置・重複完了・境界値テスト
- `frontend/src/components/MissionCard.test.tsx` — コンポーネント描画・操作テスト

## Test plan
- [x] `go test -race ./...` — 全パス
- [x] `pnpm test` — 14テスト全パス
- [x] `go build -o bin/api ./cmd/api` — ビルド成功

Closes #5