### PR TITLE
fix: review round 2 - CRITICAL/HIGH security and robustness fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,7 @@ make fe-test        # frontend tests
 make be-test        # backend tests
 make fe-lint        # frontend lint + typecheck
 make be-lint        # backend lint (golangci-lint)
-make migrate-up     # DB migration 適用
-make migrate-down   # DB migration ロールバック
+# migrate-up/migrate-down: removed (migrate CLI未実装)
 ```
 
 ## Rules

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fe-dev be-dev fe-test be-test fe-lint be-lint fe-build be-build migrate-up migrate-down
+.PHONY: check fe-dev be-dev fe-test be-test fe-lint be-lint fe-build be-build
 
 check: fe-lint be-lint fe-test be-test fe-build be-build
 
@@ -25,9 +25,3 @@ fe-build:
 
 be-build:
 	cd backend && go build -o bin/api ./cmd/api
-
-migrate-up:
-	cd backend && go run ./cmd/migrate up
-
-migrate-down:
-	cd backend && go run ./cmd/migrate down

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -10,7 +10,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/akaitigo/astro-karuta/backend/config"
 	"github.com/akaitigo/astro-karuta/backend/internal/handler"
+	"github.com/akaitigo/astro-karuta/backend/internal/middleware"
 	"github.com/akaitigo/astro-karuta/backend/internal/repository"
 	"github.com/akaitigo/astro-karuta/backend/internal/seed"
 	"github.com/akaitigo/astro-karuta/backend/internal/service"
@@ -18,10 +20,8 @@ import (
 )
 
 func main() {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+	// C3: use config.Load() as single source of truth for configuration
+	cfg := config.Load()
 
 	cardRepo := repository.NewInMemoryCardRepository()
 	deckRepo := repository.NewInMemoryDeckRepository()
@@ -35,7 +35,7 @@ func main() {
 	missionRepo := repository.NewInMemoryMissionRepository()
 
 	seasonalSvc := service.NewSeasonalService(cardRepo, deckRepo)
-	missionSvc := service.NewMissionService(missionRepo, cardRepo)
+	missionSvc := service.NewMissionService(missionRepo, cardRepo, collectionRepo)
 
 	cardSvc := service.NewCardService(cardRepo, deckRepo)
 	cardSvc.SetSeasonalService(seasonalSvc)
@@ -48,7 +48,7 @@ func main() {
 
 	hub := ws.NewHub()
 	gm := ws.NewGameManager(hub, cardRepo)
-	wsHandler := handler.NewWSHandler(hub, gm)
+	wsHandler := handler.NewWSHandler(hub, gm, cfg.CORSOrigin)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/health", func(w http.ResponseWriter, r *http.Request) {
@@ -60,16 +60,19 @@ func main() {
 	seasonalHandler.RegisterRoutes(mux)
 	wsHandler.RegisterRoutes(mux)
 
+	// H3: wrap mux with CORS middleware
+	corsHandler := middleware.CORS(cfg.CORSOrigin)(mux)
+
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      mux,
+		Addr:         ":" + cfg.Port,
+		Handler:      corsHandler,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
 
 	go func() {
-		log.Printf("server starting on :%s", port)
+		log.Printf("server starting on :%s", cfg.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server error: %v", err)
 		}

--- a/backend/internal/handler/collection_handler.go
+++ b/backend/internal/handler/collection_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/akaitigo/astro-karuta/backend/internal/service"
+	"github.com/google/uuid"
 )
 
 // CollectionHandler handles HTTP requests for collection endpoints.
@@ -29,6 +30,11 @@ func (h *CollectionHandler) ListCollection(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, "user_id query parameter is required")
 		return
 	}
+	// C5: validate user_id is a valid UUID
+	if _, err := uuid.Parse(userID); err != nil {
+		writeError(w, http.StatusBadRequest, "user_id must be a valid UUID")
+		return
+	}
 
 	category := r.URL.Query().Get("category")
 
@@ -46,6 +52,11 @@ func (h *CollectionHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 	userID := r.URL.Query().Get("user_id")
 	if userID == "" {
 		writeError(w, http.StatusBadRequest, "user_id query parameter is required")
+		return
+	}
+	// C5: validate user_id is a valid UUID
+	if _, err := uuid.Parse(userID); err != nil {
+		writeError(w, http.StatusBadRequest, "user_id must be a valid UUID")
 		return
 	}
 

--- a/backend/internal/handler/collection_handler_test.go
+++ b/backend/internal/handler/collection_handler_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/akaitigo/astro-karuta/backend/internal/service"
 )
 
+// Test UUIDs for handler tests (C5: user_id must be valid UUID)
+const (
+	testUserID1 = "00000000-0000-0000-0000-000000000001"
+	testUserID2 = "00000000-0000-0000-0000-000000000002"
+)
+
 func setupCollectionHandler(t *testing.T) (*http.ServeMux, *repository.InMemoryCollectionRepository) {
 	t.Helper()
 	cardRepo := repository.NewInMemoryCardRepository()
@@ -35,11 +41,11 @@ func TestListCollection_Success(t *testing.T) {
 	ctx := context.Background()
 
 	// Add some entries
-	if err := collectionRepo.AddToCollection(ctx, "user-1", "card-1", "game"); err != nil {
+	if err := collectionRepo.AddToCollection(ctx, testUserID1, "card-1", "game"); err != nil {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=user-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=00000000-0000-0000-0000-000000000001", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -71,7 +77,7 @@ func TestListCollection_MissingUserID(t *testing.T) {
 func TestListCollection_EmptyCollection(t *testing.T) {
 	mux, _ := setupCollectionHandler(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=user-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=00000000-0000-0000-0000-000000000001", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -91,7 +97,7 @@ func TestListCollection_EmptyCollection(t *testing.T) {
 func TestListCollection_InvalidCategory(t *testing.T) {
 	mux, _ := setupCollectionHandler(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=user-1&category=invalid", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=00000000-0000-0000-0000-000000000001&category=invalid", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -108,15 +114,15 @@ func TestListCollection_FilterByCategory(t *testing.T) {
 	// that exist in the collection repo (the card_id might not match seed data,
 	// but GetCollection with category filter needs the card to exist in cardRepo)
 	// For this test, we add entries and filter without category
-	if err := collectionRepo.AddToCollection(ctx, "user-1", "card-A", "game"); err != nil {
+	if err := collectionRepo.AddToCollection(ctx, testUserID1, "card-A", "game"); err != nil {
 		t.Fatal(err)
 	}
-	if err := collectionRepo.AddToCollection(ctx, "user-1", "card-B", "mission"); err != nil {
+	if err := collectionRepo.AddToCollection(ctx, testUserID1, "card-B", "mission"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Without category filter, should return all entries
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=user-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=00000000-0000-0000-0000-000000000001", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -137,11 +143,11 @@ func TestGetStats_Success(t *testing.T) {
 	mux, collectionRepo := setupCollectionHandler(t)
 	ctx := context.Background()
 
-	if err := collectionRepo.AddToCollection(ctx, "user-1", "card-1", "game"); err != nil {
+	if err := collectionRepo.AddToCollection(ctx, testUserID1, "card-1", "game"); err != nil {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections/stats?user_id=user-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections/stats?user_id=00000000-0000-0000-0000-000000000001", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -153,7 +159,7 @@ func TestGetStats_Success(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
 		t.Fatalf("failed to decode: %v", err)
 	}
-	if stats.UserID != "user-1" {
+	if stats.UserID != testUserID1 {
 		t.Errorf("expected user-1, got %s", stats.UserID)
 	}
 	if stats.Collected != 1 {
@@ -180,7 +186,7 @@ func TestGetStats_MissingUserID(t *testing.T) {
 func TestGetStats_EmptyCollection(t *testing.T) {
 	mux, _ := setupCollectionHandler(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections/stats?user_id=new-user", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections/stats?user_id=00000000-0000-0000-0000-000000000002", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -197,5 +203,30 @@ func TestGetStats_EmptyCollection(t *testing.T) {
 	}
 	if stats.Percentage != 0.0 {
 		t.Errorf("expected 0.0%%, got %.1f%%", stats.Percentage)
+	}
+}
+
+// C5: test invalid UUID format
+func TestListCollection_InvalidUserIDFormat(t *testing.T) {
+	mux, _ := setupCollectionHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections?user_id=not-a-uuid", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestGetStats_InvalidUserIDFormat(t *testing.T) {
+	mux, _ := setupCollectionHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collections/stats?user_id=invalid", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
 	}
 }

--- a/backend/internal/handler/seasonal_handler.go
+++ b/backend/internal/handler/seasonal_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/akaitigo/astro-karuta/backend/internal/model"
 	"github.com/akaitigo/astro-karuta/backend/internal/service"
+	"github.com/google/uuid"
 )
 
 // SeasonalHandler handles HTTP requests for seasonal and mission endpoints.
@@ -35,6 +36,11 @@ func (h *SeasonalHandler) ListMissions(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "user_id is required")
 		return
 	}
+	// C5: validate user_id is a valid UUID
+	if _, err := uuid.Parse(userID); err != nil {
+		writeError(w, http.StatusBadRequest, "user_id must be a valid UUID")
+		return
+	}
 
 	missions, err := h.missionSvc.GetActiveMissions(r.Context(), userID)
 	if err != nil {
@@ -61,6 +67,11 @@ func (h *SeasonalHandler) CompleteMission(w http.ResponseWriter, r *http.Request
 
 	if req.UserID == "" {
 		writeError(w, http.StatusBadRequest, "user_id is required")
+		return
+	}
+	// C5: validate user_id is a valid UUID
+	if _, err := uuid.Parse(req.UserID); err != nil {
+		writeError(w, http.StatusBadRequest, "user_id must be a valid UUID")
 		return
 	}
 

--- a/backend/internal/handler/ws_handler.go
+++ b/backend/internal/handler/ws_handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -22,16 +21,17 @@ const (
 	maxWSConnections = 200
 )
 
-// allowedOrigins returns the set of allowed WebSocket origins from the
-// CORS_ORIGIN environment variable. Multiple origins can be separated by
-// commas. When the variable is empty the default development origin is used.
-func allowedOrigins() map[string]bool {
-	raw := os.Getenv("CORS_ORIGIN")
-	if raw == "" {
-		raw = "http://localhost:3000"
+// parseAllowedOrigins builds a set of allowed origins from the CORS config string.
+// If corsOrigin is "*", returns nil to indicate all origins are allowed (dev mode).
+func parseAllowedOrigins(corsOrigin string) map[string]bool {
+	if corsOrigin == "*" {
+		return nil // nil signals "allow all"
+	}
+	if corsOrigin == "" {
+		corsOrigin = "http://localhost:3000"
 	}
 	origins := make(map[string]bool)
-	for _, o := range strings.Split(raw, ",") {
+	for _, o := range strings.Split(corsOrigin, ",") {
 		o = strings.TrimSpace(o)
 		if o != "" {
 			origins[o] = true
@@ -40,29 +40,37 @@ func allowedOrigins() map[string]bool {
 	return origins
 }
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		origin := r.Header.Get("Origin")
-		if origin == "" {
-			// Allow connections without an Origin header (e.g. non-browser clients).
-			return true
-		}
-		return allowedOrigins()[origin]
-	},
-}
-
 // WSHandler handles WebSocket connections.
 type WSHandler struct {
-	hub       *ws.Hub
-	gm        *ws.GameManager
-	connCount atomic.Int64
+	hub            *ws.Hub
+	gm             *ws.GameManager
+	connCount      atomic.Int64
+	upgrader       websocket.Upgrader
 }
 
 // NewWSHandler creates a new WSHandler.
-func NewWSHandler(hub *ws.Hub, gm *ws.GameManager) *WSHandler {
-	return &WSHandler{hub: hub, gm: gm}
+// C4: corsOrigin is passed from config to avoid direct os.Getenv usage.
+func NewWSHandler(hub *ws.Hub, gm *ws.GameManager, corsOrigin string) *WSHandler {
+	allowed := parseAllowedOrigins(corsOrigin)
+
+	h := &WSHandler{hub: hub, gm: gm}
+	h.upgrader = websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			// C4: if allowed is nil, wildcard mode (dev) -- allow everything
+			if allowed == nil {
+				return true
+			}
+			origin := r.Header.Get("Origin")
+			// C4: reject connections with empty Origin in production
+			if origin == "" {
+				return false
+			}
+			return allowed[origin]
+		},
+	}
+	return h
 }
 
 // RegisterRoutes registers WebSocket routes.
@@ -77,7 +85,7 @@ func (h *WSHandler) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conn, err := upgrader.Upgrade(w, r, nil)
+	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Printf("ws upgrade error: %v", err)
 		return

--- a/backend/internal/middleware/cors.go
+++ b/backend/internal/middleware/cors.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CORS returns middleware that adds Cross-Origin Resource Sharing headers.
+// If corsOrigin is "*", all origins are allowed (development mode).
+// Multiple origins can be separated by commas.
+func CORS(corsOrigin string) func(http.Handler) http.Handler {
+	allowAll := corsOrigin == "*"
+	var allowedSet map[string]bool
+	if !allowAll && corsOrigin != "" {
+		allowedSet = make(map[string]bool)
+		for _, o := range strings.Split(corsOrigin, ",") {
+			o = strings.TrimSpace(o)
+			if o != "" {
+				allowedSet[o] = true
+			}
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			if allowAll {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else if origin != "" && allowedSet[origin] {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+			}
+
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+
+			// Handle preflight
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/middleware/cors_test.go
+++ b/backend/internal/middleware/cors_test.go
@@ -1,0 +1,91 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/akaitigo/astro-karuta/backend/internal/middleware"
+)
+
+func TestCORS_Wildcard(t *testing.T) {
+	handler := middleware.CORS("*")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://example.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("expected *, got %s", got)
+	}
+}
+
+func TestCORS_AllowedOrigin(t *testing.T) {
+	handler := middleware.CORS("http://localhost:3000,http://example.com")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://example.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://example.com" {
+		t.Errorf("expected http://example.com, got %s", got)
+	}
+}
+
+func TestCORS_DisallowedOrigin(t *testing.T) {
+	handler := middleware.CORS("http://localhost:3000")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected empty, got %s", got)
+	}
+}
+
+func TestCORS_Preflight(t *testing.T) {
+	handler := middleware.CORS("http://localhost:3000")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Error("expected Access-Control-Allow-Methods to be set")
+	}
+}
+
+func TestCORS_NoOriginHeader(t *testing.T) {
+	handler := middleware.CORS("http://localhost:3000")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// No Origin header
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Should not set Allow-Origin when no Origin provided
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected empty, got %s", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}

--- a/backend/internal/service/mission_service.go
+++ b/backend/internal/service/mission_service.go
@@ -18,17 +18,20 @@ const maxLatitudeDeviation = 30.0
 
 // MissionService provides business logic for observation missions.
 type MissionService struct {
-	missionRepo repository.MissionRepository
-	cardRepo    repository.CardRepository
-	nowFunc     func() time.Time
+	missionRepo    repository.MissionRepository
+	cardRepo       repository.CardRepository
+	collectionRepo repository.CollectionRepository
+	nowFunc        func() time.Time
 }
 
 // NewMissionService creates a new MissionService.
-func NewMissionService(missionRepo repository.MissionRepository, cardRepo repository.CardRepository) *MissionService {
+// H10: collectionRepo is injected to auto-add bonus cards to the user's collection.
+func NewMissionService(missionRepo repository.MissionRepository, cardRepo repository.CardRepository, collectionRepo repository.CollectionRepository) *MissionService {
 	return &MissionService{
-		missionRepo: missionRepo,
-		cardRepo:    cardRepo,
-		nowFunc:     time.Now,
+		missionRepo:    missionRepo,
+		cardRepo:       cardRepo,
+		collectionRepo: collectionRepo,
+		nowFunc:        time.Now,
 	}
 }
 
@@ -77,7 +80,8 @@ func (s *MissionService) GetActiveMissions(ctx context.Context, userID string) (
 	}
 
 	// Create up to 5 missions from visible constellations
-	validFrom := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.Local)
+	// H7: use UTC for consistency. Client timezone handling is deferred to future work.
+	validFrom := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	validTo := validFrom.AddDate(0, 1, 0).Add(-time.Second)
 
 	var generated []model.UserMission
@@ -119,6 +123,11 @@ func (s *MissionService) CompleteMission(ctx context.Context, userID string, mis
 	}
 	if missionID == "" {
 		return nil, fmt.Errorf("mission ID must not be empty")
+	}
+
+	// H6: reject zero-value coordinates (likely uninitialized / missing GPS)
+	if lat == 0 && lng == 0 {
+		return nil, fmt.Errorf("coordinates must not be zero (lat=0, lng=0); GPS data is required")
 	}
 
 	mission, err := s.missionRepo.GetByID(ctx, missionID)
@@ -168,6 +177,11 @@ func (s *MissionService) CompleteMission(ctx context.Context, userID string, mis
 		return nil, fmt.Errorf("get bonus card: %w", err)
 	}
 
+	// H10: auto-add the bonus card to the user's collection
+	if err := s.collectionRepo.AddToCollection(ctx, userID, mission.CardID, "mission"); err != nil {
+		return nil, fmt.Errorf("add bonus card to collection: %w", err)
+	}
+
 	return &model.CompleteMissionResponse{
 		Mission:   *mission,
 		BonusCard: card,
@@ -175,6 +189,7 @@ func (s *MissionService) CompleteMission(ctx context.Context, userID string, mis
 }
 
 // validateNighttime checks that the time is between 18:00 and 06:00.
+// H7: UTC-based. Client timezone conversion is deferred to future work.
 func validateNighttime(t time.Time) error {
 	hour := t.Hour()
 	if hour >= 6 && hour < 18 {

--- a/backend/internal/service/mission_service_test.go
+++ b/backend/internal/service/mission_service_test.go
@@ -14,11 +14,12 @@ func setupMissionService(t *testing.T) (*service.MissionService, *repository.InM
 	t.Helper()
 	cardRepo := repository.NewInMemoryCardRepository()
 	missionRepo := repository.NewInMemoryMissionRepository()
+	collectionRepo := repository.NewInMemoryCollectionRepository(cardRepo)
 
 	if err := seed.LoadCards(context.Background(), cardRepo); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewMissionService(missionRepo, cardRepo)
+	svc := service.NewMissionService(missionRepo, cardRepo, collectionRepo)
 	return svc, cardRepo
 }
 
@@ -36,7 +37,7 @@ func TestMissionService_GetActiveMissions_GeneratesMissions(t *testing.T) {
 
 	// Set time to July (summer) for predictable results
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 20, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 20, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -64,7 +65,7 @@ func TestMissionService_GetActiveMissions_ReturnsCached(t *testing.T) {
 	svc, _ := setupMissionService(t)
 
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 20, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 20, 0, 0, 0, time.UTC)
 	})
 
 	// First call generates
@@ -89,7 +90,7 @@ func TestMissionService_CompleteMission_Success(t *testing.T) {
 
 	// Generate missions at nighttime in July
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -138,7 +139,7 @@ func TestMissionService_CompleteMission_WrongUser(t *testing.T) {
 	svc, _ := setupMissionService(t)
 
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -158,7 +159,7 @@ func TestMissionService_CompleteMission_Daytime(t *testing.T) {
 
 	// Generate at night
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -168,7 +169,7 @@ func TestMissionService_CompleteMission_Daytime(t *testing.T) {
 
 	// Try to complete during daytime
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 12, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	})
 
 	_, err = svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 35.0, 139.0)
@@ -181,7 +182,7 @@ func TestMissionService_CompleteMission_LocationTooFar(t *testing.T) {
 	svc, _ := setupMissionService(t)
 
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -200,7 +201,7 @@ func TestMissionService_CompleteMission_AlreadyCompleted(t *testing.T) {
 	svc, _ := setupMissionService(t)
 
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -221,12 +222,84 @@ func TestMissionService_CompleteMission_AlreadyCompleted(t *testing.T) {
 	}
 }
 
+func TestMissionService_CompleteMission_ZeroCoordinates(t *testing.T) {
+	svc, _ := setupMissionService(t)
+
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// H6: lat=0 AND lng=0 should be rejected
+	_, err = svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 0.0, 0.0)
+	if err == nil {
+		t.Fatal("expected error for zero coordinates")
+	}
+}
+
+func TestMissionService_CompleteMission_AddsToCollection(t *testing.T) {
+	cardRepo := repository.NewInMemoryCardRepository()
+	missionRepo := repository.NewInMemoryMissionRepository()
+	collectionRepo := repository.NewInMemoryCollectionRepository(cardRepo)
+
+	if err := seed.LoadCards(context.Background(), cardRepo); err != nil {
+		t.Fatal(err)
+	}
+	svc := service.NewMissionService(missionRepo, cardRepo, collectionRepo)
+
+	// Generate missions at nighttime in July
+	svc.SetNowFunc(func() time.Time {
+		return time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)
+	})
+
+	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missions) == 0 {
+		t.Fatal("expected missions to be generated")
+	}
+
+	// Complete the first mission
+	resp, err := svc.CompleteMission(context.Background(), "user-1", missions[0].ID, 35.0, 139.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.BonusCard == nil {
+		t.Fatal("expected bonus card")
+	}
+
+	// H10: verify the card was added to the collection
+	entries, err := collectionRepo.GetCollection(context.Background(), "user-1", "")
+	if err != nil {
+		t.Fatalf("unexpected error getting collection: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one collection entry after mission completion")
+	}
+
+	found := false
+	for _, e := range entries {
+		if e.CardID == missions[0].CardID && e.Source == "mission" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("bonus card not found in collection with source=mission")
+	}
+}
+
 func TestMissionService_CompleteMission_NighttimeBoundary(t *testing.T) {
 	svc, _ := setupMissionService(t)
 
 	// Generate missions
 	svc.SetNowFunc(func() time.Time {
-		return time.Date(2026, 7, 15, 22, 0, 0, 0, time.Local)
+		return time.Date(2026, 7, 15, 22, 0, 0, 0, time.UTC)
 	})
 
 	missions, err := svc.GetActiveMissions(context.Background(), "user-1")
@@ -254,7 +327,7 @@ func TestMissionService_CompleteMission_NighttimeBoundary(t *testing.T) {
 			// Re-setup to get fresh missions
 			innerSvc, _ := setupMissionService(t)
 			innerSvc.SetNowFunc(func() time.Time {
-				return time.Date(2026, 7, 15, 22, 0, 0, 0, time.Local)
+				return time.Date(2026, 7, 15, 22, 0, 0, 0, time.UTC)
 			})
 
 			innerMissions, err := innerSvc.GetActiveMissions(context.Background(), "user-1")
@@ -264,7 +337,7 @@ func TestMissionService_CompleteMission_NighttimeBoundary(t *testing.T) {
 			_ = missionID // referenced from outer scope only as pattern
 
 			innerSvc.SetNowFunc(func() time.Time {
-				return time.Date(2026, 7, 15, tc.hour, 0, 0, 0, time.Local)
+				return time.Date(2026, 7, 15, tc.hour, 0, 0, 0, time.UTC)
 			})
 
 			_, err = innerSvc.CompleteMission(context.Background(), "user-1", innerMissions[0].ID, 35.0, 139.0)

--- a/backend/internal/service/seasonal_service.go
+++ b/backend/internal/service/seasonal_service.go
@@ -71,9 +71,10 @@ func (s *SeasonalService) GenerateSeasonalDeck(ctx context.Context, month int) (
 	}
 
 	// Build the valid time range for this month
-	now := time.Now()
+	// H7: use UTC for consistency. Client timezone handling is deferred to future work.
+	now := time.Now().UTC()
 	year := now.Year()
-	validFrom := time.Date(year, m, 1, 0, 0, 0, 0, time.Local)
+	validFrom := time.Date(year, m, 1, 0, 0, 0, 0, time.UTC)
 	validTo := validFrom.AddDate(0, 1, 0).Add(-time.Second)
 
 	deck := &model.Deck{

--- a/backend/internal/ws/game_manager.go
+++ b/backend/internal/ws/game_manager.go
@@ -8,8 +8,11 @@ import (
 	"log"
 	"math/big"
 	mrand "math/rand"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/akaitigo/astro-karuta/backend/internal/model"
 	"github.com/akaitigo/astro-karuta/backend/internal/repository"
@@ -17,10 +20,15 @@ import (
 )
 
 const (
-	maxPlayersPerRoom = 2
-	reconnectTimeout  = 30 * time.Second
-	defaultTimeLimit  = 300 // 5 minutes
+	maxPlayersPerRoom  = 2
+	reconnectTimeout   = 30 * time.Second
+	defaultTimeLimit   = 300 // 5 minutes
+	maxPlayerNameLen   = 20
+	roomCodeLen        = 6
 )
+
+// roomCodeRegex validates that a room code is uppercase alphanumeric, 6 characters.
+var roomCodeRegex = regexp.MustCompile(`^[A-Z0-9]{6}$`)
 
 // GameState holds the state of an active game.
 type GameState struct {
@@ -48,6 +56,7 @@ type PlayerState struct {
 	CapturedIDs  []string
 	IsConnected  bool
 	DisconnectAt *time.Time
+	HasGrabbed   bool
 }
 
 // GameManager coordinates matchmaking and game lifecycle.
@@ -72,8 +81,38 @@ func NewGameManager(hub *Hub, cardRepo repository.CardRepository) *GameManager {
 	}
 }
 
+// validatePlayerName validates the player name: non-empty, max 20 chars, no control characters.
+func validatePlayerName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("player name must not be empty")
+	}
+	if utf8.RuneCountInString(name) > maxPlayerNameLen {
+		return fmt.Errorf("player name must be at most %d characters", maxPlayerNameLen)
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("player name must not contain control characters")
+		}
+	}
+	return nil
+}
+
+// validateRoomCode validates a user-supplied room code: uppercase alphanumeric, 6 chars.
+func validateRoomCode(code string) error {
+	if !roomCodeRegex.MatchString(code) {
+		return fmt.Errorf("room code must be exactly %d uppercase alphanumeric characters", roomCodeLen)
+	}
+	return nil
+}
+
 // HandleJoin processes a player's join request.
 func (gm *GameManager) HandleJoin(clientID string, payload JoinPayload) {
+	// C1: validate player name
+	if err := validatePlayerName(payload.PlayerName); err != nil {
+		gm.sendError(clientID, err.Error())
+		return
+	}
+
 	if payload.RandomMatch {
 		gm.handleRandomMatch(clientID, payload.PlayerName)
 		return
@@ -82,6 +121,12 @@ func (gm *GameManager) HandleJoin(clientID string, payload JoinPayload) {
 	roomCode := payload.RoomCode
 	if roomCode == "" {
 		roomCode = generateRoomCode()
+	} else {
+		// C1: validate user-supplied room code
+		if err := validateRoomCode(roomCode); err != nil {
+			gm.sendError(clientID, err.Error())
+			return
+		}
 	}
 
 	gm.mu.Lock()
@@ -287,6 +332,11 @@ func (gm *GameManager) revealNextCard(game *GameState) {
 	game.CurrentCard = &card
 	game.GrabHandled = false
 
+	// H2: reset grab flag for all players at the start of each round
+	for _, p := range game.Players {
+		p.HasGrabbed = false
+	}
+
 	// Build candidate list: correct card + 3 distractors
 	candidates := []model.Card{card}
 	for i, c := range game.Cards {
@@ -333,6 +383,15 @@ func (gm *GameManager) HandleGrab(clientID string, payload GrabPayload) {
 		return
 	}
 
+	// C2: verify the game is in playing state
+	game.mu.RLock()
+	if game.Status != model.GameStatusPlaying {
+		game.mu.RUnlock()
+		gm.sendError(clientID, "game is not in playing state")
+		return
+	}
+	game.mu.RUnlock()
+
 	game.GrabLock.Lock()
 	defer game.GrabLock.Unlock()
 
@@ -342,6 +401,13 @@ func (gm *GameManager) HandleGrab(clientID string, payload GrabPayload) {
 		return
 	}
 	currentCard := game.CurrentCard
+
+	// H2: check if player already grabbed this round
+	if player, ok := game.Players[clientID]; ok && player.HasGrabbed {
+		game.mu.RUnlock()
+		gm.sendError(clientID, "you already grabbed this round")
+		return
+	}
 	game.mu.RUnlock()
 
 	if currentCard == nil {
@@ -351,6 +417,11 @@ func (gm *GameManager) HandleGrab(clientID string, payload GrabPayload) {
 	correct := payload.CardID == currentCard.ID
 
 	game.mu.Lock()
+
+	// H2: mark player as having grabbed this round
+	if player, ok := game.Players[clientID]; ok {
+		player.HasGrabbed = true
+	}
 
 	playerName := ""
 	if correct {
@@ -386,6 +457,9 @@ func (gm *GameManager) HandleGrab(clientID string, payload GrabPayload) {
 }
 
 // HandleReconnect processes a reconnect attempt.
+// H1: In MVP (no auth tokens), reconnect is allowed for any client but a
+// warning is logged when the new clientID differs from the original. Full
+// session-token validation is deferred to post-MVP (see ADR-003).
 func (gm *GameManager) HandleReconnect(clientID string, payload ReconnectPayload) {
 	gm.mu.RLock()
 	game, ok := gm.games[payload.GameID]
@@ -402,6 +476,12 @@ func (gm *GameManager) HandleReconnect(clientID string, payload ReconnectPayload
 		game.mu.Unlock()
 		gm.sendError(clientID, "player not found in game")
 		return
+	}
+
+	// H1: warn if a different clientID is reconnecting as this player
+	if player.ClientID != clientID {
+		log.Printf("WARN: reconnect for player %s: original clientID=%s, new clientID=%s (MVP allows, production requires auth token)",
+			payload.PlayerID, player.ClientID, clientID)
 	}
 
 	player.IsConnected = true

--- a/backend/internal/ws/game_manager_test.go
+++ b/backend/internal/ws/game_manager_test.go
@@ -261,3 +261,238 @@ func TestGameManager_ProcessMessage_UnknownType(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+// --- C1: PlayerName validation tests ---
+
+func TestGameManager_Join_EmptyPlayerName(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "", RandomMatch: true})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for empty name, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestGameManager_Join_PlayerNameTooLong(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	longName := "ABCDEFGHIJKLMNOPQRSTU" // 21 chars
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: longName, RandomMatch: true})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for long name, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestGameManager_Join_PlayerNameControlChars(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "bad\x00name", RandomMatch: true})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for control chars, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// --- C1: RoomCode validation tests ---
+
+func TestGameManager_Join_InvalidRoomCode(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	// lowercase is invalid
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "Alice", RoomCode: "abcdef"})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for invalid room code, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestGameManager_Join_RoomCodeWrongLength(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "Alice", RoomCode: "ABC"})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for short room code, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestGameManager_Join_ValidRoomCode(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "Alice", RoomCode: "ABC123"})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		// Should get player_joined (not error)
+		if m.Type != ws.MsgPlayerJoined {
+			t.Errorf("expected player_joined, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// --- C2: HandleGrab when not playing ---
+
+func TestGameManager_GrabNotPlaying(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	hub.Register(c1)
+
+	// Create a room but don't start the game (only 1 player, status=waiting)
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "Alice", RoomCode: "TEST99"})
+	<-c1.Send // drain player_joined
+
+	// Try to grab
+	gm.HandleGrab("p1", ws.GrabPayload{CardID: "card-1"})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for grab-while-not-playing, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// --- H2: grab limit per round ---
+
+func TestGameManager_GrabLimitPerRound(t *testing.T) {
+	hub := ws.NewHub()
+	repo := seedTestCards(t)
+	gm := ws.NewGameManager(hub, repo)
+
+	c1 := newTestClient("p1", "")
+	c2 := newTestClient("p2", "")
+	hub.Register(c1)
+	hub.Register(c2)
+
+	// Setup match
+	gm.HandleJoin("p1", ws.JoinPayload{PlayerName: "P1", RandomMatch: true})
+	<-c1.Send // waiting
+
+	gm.HandleJoin("p2", ws.JoinPayload{PlayerName: "P2", RandomMatch: true})
+	<-c1.Send // match_found
+	<-c2.Send // match_found
+
+	// Get card_revealed
+	msg1 := <-c1.Send
+	<-c2.Send // drain c2's card_revealed
+
+	var cardMsg ws.Message
+	if err := json.Unmarshal(msg1, &cardMsg); err != nil {
+		t.Fatal(err)
+	}
+
+	// First grab (wrong card on purpose)
+	gm.HandleGrab("p1", ws.GrabPayload{CardID: "wrong-card-id"})
+
+	// Drain grab_result for both
+	<-c1.Send
+	<-c2.Send
+
+	// Second grab should be rejected (already grabbed this round)
+	gm.HandleGrab("p1", ws.GrabPayload{CardID: "another-wrong-id"})
+
+	select {
+	case raw := <-c1.Send:
+		var m ws.Message
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m.Type != ws.MsgError {
+			t.Errorf("expected error for duplicate grab, got %s", m.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/backend/migrations/002_user_missions.down.sql
+++ b/backend/migrations/002_user_missions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_missions;

--- a/backend/migrations/002_user_missions.up.sql
+++ b/backend/migrations/002_user_missions.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS user_missions (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL REFERENCES users(id),
+    mission_id   TEXT NOT NULL,
+    card_id      UUID NOT NULL REFERENCES cards(id),
+    title        TEXT NOT NULL,
+    description  TEXT NOT NULL DEFAULT '',
+    status       TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'expired')),
+    valid_from   TIMESTAMPTZ NOT NULL,
+    valid_to     TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_missions_user_id ON user_missions(user_id);
+CREATE INDEX idx_user_missions_status ON user_missions(user_id, status);
+CREATE INDEX idx_user_missions_valid ON user_missions(valid_from, valid_to);

--- a/docs/adr/ADR-003-deferred-authentication.md
+++ b/docs/adr/ADR-003-deferred-authentication.md
@@ -1,0 +1,34 @@
+# ADR-003: Deferred Authentication
+
+## Status
+Accepted
+
+## Context
+Astro-Karuta is currently in MVP phase. Full user authentication (login, session
+management, token validation) adds significant complexity that is not required
+for the core educational game loop.
+
+However, several security-sensitive paths exist:
+
+1. **REST endpoints** (`/api/v1/collections`, `/api/v1/missions`) accept a
+   `user_id` query parameter without verifying ownership.
+2. **WebSocket reconnect** (`HandleReconnect`) allows a new client to resume
+   any player session by providing the correct `game_id` and `player_id`.
+3. **Mission completion** credits bonus cards to any supplied `user_id`.
+
+## Decision
+- **MVP (current):** Validate `user_id` format (UUID) at the handler level.
+  Reject empty or malformed values with 400 Bad Request. Log warnings when
+  WebSocket reconnect occurs from a different `clientID` than the original.
+- **Post-MVP:** Implement session-based or JWT authentication.
+  - REST endpoints: require `Authorization` header; derive `user_id` from
+    the verified token.
+  - WebSocket reconnect: require a reconnect token issued at initial
+    connection. Reject reconnect attempts without a valid token.
+
+## Consequences
+- MVP users can impersonate other users by guessing UUIDs. This is acceptable
+  because the MVP is not publicly deployed and UUIDs are random.
+- Post-MVP must introduce authentication before any public deployment.
+- The reconnect warning log enables monitoring for suspicious activity
+  during the MVP period.

--- a/frontend/src/app/lobby/page.tsx
+++ b/frontend/src/app/lobby/page.tsx
@@ -60,12 +60,13 @@ export default function LobbyPage() {
     [router],
   );
 
-  const { send, connect, status } = useWebSocket({
+  const { send, connect, status, waitForConnection } = useWebSocket({
     url: WS_URL,
     onMessage: handleMessage,
     autoConnect: false,
   });
 
+  // H9: use waitForConnection instead of fragile setTimeout
   const ensureConnectedAndSend = useCallback(
     (
       roomCodeVal: string,
@@ -79,16 +80,15 @@ export default function LobbyPage() {
       }
 
       connect();
-      // Wait for connection to establish before sending
-      setTimeout(() => {
+      void waitForConnection().then(() => {
         send("join", {
           room_code: roomCodeVal,
           player_name: playerNameVal,
           random_match: randomMatch,
         });
-      }, 200);
+      });
     },
-    [connect, send],
+    [connect, send, waitForConnection],
   );
 
   const handleRandomMatch = useCallback(() => {

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -9,6 +9,7 @@ import type {
   CardRevealedPayload,
   GrabResultPayload,
   GameOverPayload,
+  GameStatePayload,
   PlayerJoinedPayload,
   PlayerResult,
   WaitingPayload,
@@ -58,6 +59,7 @@ type GameAction =
   | { type: "CARD_REVEALED"; payload: CardRevealedPayload }
   | { type: "GRAB_RESULT"; payload: GrabResultPayload }
   | { type: "GAME_OVER"; payload: GameOverPayload }
+  | { type: "GAME_STATE"; payload: GameStatePayload }
   | { type: "WAITING"; payload: WaitingPayload }
   | { type: "MATCH_FOUND"; roomCode: string }
   | { type: "ERROR"; message: string }
@@ -130,6 +132,15 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         scores: scoreMap,
       };
     }
+
+    // H4: handle game_state message from reconnect
+    case "GAME_STATE":
+      return {
+        ...state,
+        gameStatus: action.payload.status,
+        cardIndex: action.payload.current_index,
+        totalCards: action.payload.total_cards,
+      };
 
     case "WAITING":
       return { ...state, gameStatus: "matchmaking" };
@@ -208,6 +219,17 @@ function isErrorPayload(v: unknown): v is ErrorPayload {
   return typeof obj.message === "string";
 }
 
+function isGameStatePayload(v: unknown): v is GameStatePayload {
+  if (typeof v !== "object" || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    typeof obj.game_id === "string" &&
+    typeof obj.current_index === "number" &&
+    typeof obj.total_cards === "number" &&
+    typeof obj.status === "string"
+  );
+}
+
 function isMatchFoundPayload(
   v: unknown,
 ): v is { room_code: string } {
@@ -245,6 +267,13 @@ export function useGame({ wsUrl }: UseGameOptions): UseGameReturn {
         }
         break;
 
+      // H4: handle game_state from reconnect
+      case "game_state":
+        if (isGameStatePayload(message.payload)) {
+          dispatch({ type: "GAME_STATE", payload: message.payload });
+        }
+        break;
+
       case "waiting":
         if (isWaitingPayload(message.payload)) {
           dispatch({ type: "WAITING", payload: message.payload });
@@ -268,11 +297,22 @@ export function useGame({ wsUrl }: UseGameOptions): UseGameReturn {
     }
   }, []);
 
-  const { status, send, connect, disconnect } = useWebSocket({
+  const { status, send, connect, disconnect, waitForConnection } = useWebSocket({
     url: wsUrl,
     onMessage: handleMessage,
     autoConnect: false,
   });
+
+  // H9: helper to connect and wait for open before sending
+  const connectAndSend = useCallback(
+    (payload: { room_code: string; player_name: string; random_match: boolean }) => {
+      connect();
+      void waitForConnection().then(() => {
+        send("join", payload);
+      });
+    },
+    [connect, waitForConnection, send],
+  );
 
   const joinRoom = useCallback(
     (roomCode: string, playerName: string) => {
@@ -281,17 +321,13 @@ export function useGame({ wsUrl }: UseGameOptions): UseGameReturn {
         playerId: "",
         playerName,
       });
-      connect();
-      // Send join after a short delay for the connection to establish
-      setTimeout(() => {
-        send("join", {
-          room_code: roomCode,
-          player_name: playerName,
-          random_match: false,
-        });
-      }, 100);
+      connectAndSend({
+        room_code: roomCode,
+        player_name: playerName,
+        random_match: false,
+      });
     },
-    [connect, send],
+    [connectAndSend],
   );
 
   const createRoom = useCallback(
@@ -301,16 +337,13 @@ export function useGame({ wsUrl }: UseGameOptions): UseGameReturn {
         playerId: "",
         playerName,
       });
-      connect();
-      setTimeout(() => {
-        send("join", {
-          room_code: "",
-          player_name: playerName,
-          random_match: false,
-        });
-      }, 100);
+      connectAndSend({
+        room_code: "",
+        player_name: playerName,
+        random_match: false,
+      });
     },
-    [connect, send],
+    [connectAndSend],
   );
 
   const randomMatch = useCallback(
@@ -321,16 +354,13 @@ export function useGame({ wsUrl }: UseGameOptions): UseGameReturn {
         playerName,
       });
       dispatch({ type: "START_MATCHMAKING" });
-      connect();
-      setTimeout(() => {
-        send("join", {
-          room_code: "",
-          player_name: playerName,
-          random_match: true,
-        });
-      }, 100);
+      connectAndSend({
+        room_code: "",
+        player_name: playerName,
+        random_match: true,
+      });
     },
-    [connect, send],
+    [connectAndSend],
   );
 
   const grabCard = useCallback(

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -19,6 +19,8 @@ interface UseWebSocketReturn {
   send: (type: WSMessageType, payload: unknown) => void;
   connect: () => void;
   disconnect: () => void;
+  /** H9: returns a promise that resolves when the connection is open */
+  waitForConnection: () => Promise<void>;
 }
 
 const BASE_DELAY_MS = 1000;
@@ -65,6 +67,9 @@ export function useWebSocket({
     }
   }, []);
 
+  // H9: pending resolve for waitForConnection promise
+  const pendingOpenRef = useRef<Array<() => void>>([]);
+
   // Use a ref-based connect to avoid circular dependency in useCallback
   const connectImplRef = useRef<() => void>(() => {});
 
@@ -85,6 +90,11 @@ export function useWebSocket({
     ws.onopen = () => {
       setStatus("connected");
       reconnectAttemptRef.current = 0;
+      // H9: resolve all pending waitForConnection promises
+      for (const resolve of pendingOpenRef.current) {
+        resolve();
+      }
+      pendingOpenRef.current = [];
     };
 
     ws.onmessage = (event: MessageEvent) => {
@@ -148,6 +158,16 @@ export function useWebSocket({
     [],
   );
 
+  // H9: wait until the WebSocket connection is open, resolving immediately if already open
+  const waitForConnection = useCallback((): Promise<void> => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      pendingOpenRef.current.push(resolve);
+    });
+  }, []);
+
   useEffect(() => {
     if (autoConnect) {
       connect();
@@ -155,6 +175,8 @@ export function useWebSocket({
     return () => {
       intentionalCloseRef.current = true;
       clearReconnectTimer();
+      // H9: reject pending waiters on cleanup
+      pendingOpenRef.current = [];
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;
@@ -162,5 +184,5 @@ export function useWebSocket({
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { status, send, connect, disconnect };
+  return { status, send, connect, disconnect, waitForConnection };
 }

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -13,10 +13,4 @@ export interface CollectionStats {
   percentage: number;
 }
 
-export interface ObservationMission {
-  id: string;
-  card_id: string;
-  title: string;
-  valid_from: string;
-  valid_to: string;
-}
+// H4: ObservationMission removed -- unused, missions are in mission.ts

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -19,11 +19,10 @@ export interface Game {
   time_limit_sec: number;
 }
 
+// H4: removed "start" and "card_grabbed" that do not exist in backend ws/message.go
 export type WSMessageType =
   | "join"
-  | "start"
   | "card_revealed"
-  | "card_grabbed"
   | "grab"
   | "grab_result"
   | "game_over"

--- a/frontend/src/types/mission.ts
+++ b/frontend/src/types/mission.ts
@@ -20,6 +20,7 @@ export interface CompleteMissionRequest {
   lng: number;
 }
 
+// H4: bonus_card matches backend model.Card (all fields from JSON serialization)
 export interface CompleteMissionResponse {
   mission: UserMission;
   bonus_card?: {
@@ -27,6 +28,11 @@ export interface CompleteMissionResponse {
     name: string;
     category: string;
     reading_text: string;
+    image_url: string;
     description: string;
+    magnitude?: number;
+    distance?: string;
+    best_season: string;
+    created_at: string;
   };
 }


### PR DESCRIPTION
## Summary
Review Loop Round 2 の CRITICAL 5件 + HIGH 10件の指摘を修正。

### CRITICAL
- **C1**: PlayerName/RoomCode バリデーション追加（空文字・長さ・制御文字・フォーマット）
- **C2**: HandleGrab にゲーム状態チェック追加（playing以外は拒否）
- **C3**: config.Load() を main.go で一本化（os.Getenv 直接参照を排除）
- **C4**: WebSocket Origin 検証強化（本番: 空Origin拒否、開発: ワイルドカード許可）
- **C5**: REST API user_id に UUID 形式バリデーション追加 + ADR-003

### HIGH
- **H1**: reconnect 時の clientID 不一致をログ警告（MVP: 許可、本番: 認証必須をADR記載）
- **H2**: 1ラウンド1回のgrab制限（HasGrabbed フラグ、カード更新時リセット）
- **H3**: REST API CORS ミドルウェア追加（middleware/cors.go）
- **H4**: FE/BE 型定義不一致修正（start/card_grabbed削除、bonus_card一致、game_stateハンドラ追加）
- **H5**: 未実装 migrate-up/migrate-down を Makefile から削除
- **H6**: CompleteMission で lat=0 AND lng=0 の zero value を拒否
- **H7**: time.Local -> time.UTC に統一（mission/seasonal service）
- **H8**: user_missions テーブルのマイグレーション追加（002）
- **H9**: WebSocket 接続の setTimeout を waitForConnection Promise に置換
- **H10**: ミッション完了時にボーナスカードを自動でコレクションに追加

### 新規ファイル
- `backend/internal/middleware/cors.go` + テスト
- `backend/migrations/002_user_missions.{up,down}.sql`
- `docs/adr/ADR-003-deferred-authentication.md`

## Test plan
- [x] `go test -race ./...` -- 全パス
- [x] `pnpm lint && pnpm typecheck` -- エラーなし
- [x] `pnpm test` -- 65テスト全パス
- [x] `go build -o bin/api ./cmd/api` -- ビルド成功
- [x] 新規テスト: C1 バリデーション (5テスト), C2 状態チェック, H2 grab制限, H6 zero coords, H10 コレクション連携, CORS middleware (5テスト)