### PR TITLE
fix: review round 4 - errcheck, UUID user ID, promise leak

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -53,7 +53,9 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"status":"ok"}`)
+		if _, err := fmt.Fprintf(w, `{"status":"ok"}`); err != nil {
+			log.Printf("health check write error: %v", err)
+		}
 	})
 	cardHandler.RegisterRoutes(mux)
 	collectionHandler.RegisterRoutes(mux)

--- a/backend/internal/handler/ws_handler.go
+++ b/backend/internal/handler/ws_handler.go
@@ -111,7 +111,9 @@ func (h *WSHandler) readPump(client *ws.Client, connCount *atomic.Int64) {
 		connCount.Add(-1)
 		h.gm.HandleDisconnect(client.ID)
 		h.hub.Unregister(client)
-		client.Conn.Close()
+		if err := client.Conn.Close(); err != nil {
+			log.Printf("ws: conn close error: %v", err)
+		}
 	}()
 
 	client.Conn.SetReadLimit(maxMsgSize)
@@ -139,7 +141,9 @@ func (h *WSHandler) writePump(client *ws.Client) {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		client.Conn.Close()
+		if err := client.Conn.Close(); err != nil {
+			log.Printf("ws: conn close error: %v", err)
+		}
 	}()
 
 	for {

--- a/frontend/src/app/collection/page.tsx
+++ b/frontend/src/app/collection/page.tsx
@@ -17,7 +17,7 @@ const categories: { value: CategoryFilter; label: string }[] = [
 ];
 
 // Temporary user ID until auth is implemented
-const DEFAULT_USER_ID = "user-1";
+const DEFAULT_USER_ID = "00000000-0000-4000-8000-000000000001";
 
 export default function CollectionPage() {
   const [cards, setCards] = useState<Card[]>([]);

--- a/frontend/src/app/missions/page.tsx
+++ b/frontend/src/app/missions/page.tsx
@@ -8,7 +8,7 @@ import type { UserMission, CompleteMissionResponse } from "@/types/mission";
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 
 // Temporary user ID until auth is implemented
-const DEFAULT_USER_ID = "user-1";
+const DEFAULT_USER_ID = "00000000-0000-4000-8000-000000000001";
 
 export default function MissionsPage() {
   const [missions, setMissions] = useState<UserMission[]>([]);

--- a/frontend/src/components/MissionCard.test.tsx
+++ b/frontend/src/components/MissionCard.test.tsx
@@ -9,7 +9,7 @@ function createMission(overrides: Partial<UserMission> = {}): UserMission {
 
   return {
     id: "mission-1",
-    user_id: "user-1",
+    user_id: "00000000-0000-4000-8000-000000000001",
     mission_id: "obs-7-card-1",
     card_id: "card-1",
     title: "オリオン座を観測しよう",

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -307,9 +307,14 @@ export function useGame({ wsUrl }: UseGameOptions): UseGameReturn {
   const connectAndSend = useCallback(
     (payload: { room_code: string; player_name: string; random_match: boolean }) => {
       connect();
-      void waitForConnection().then(() => {
-        send("join", payload);
-      });
+      waitForConnection()
+        .then(() => {
+          send("join", payload);
+        })
+        .catch(() => {
+          // Connection was closed before open (e.g. disconnect/reset called);
+          // no action needed since disconnect already handles cleanup.
+        });
     },
     [connect, waitForConnection, send],
   );

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -67,8 +67,8 @@ export function useWebSocket({
     }
   }, []);
 
-  // H9: pending resolve for waitForConnection promise
-  const pendingOpenRef = useRef<Array<() => void>>([]);
+  // H9: pending resolve/reject for waitForConnection promise
+  const pendingOpenRef = useRef<Array<{ resolve: () => void; reject: (err: Error) => void }>>([]);
 
   // Use a ref-based connect to avoid circular dependency in useCallback
   const connectImplRef = useRef<() => void>(() => {});
@@ -91,7 +91,7 @@ export function useWebSocket({
       setStatus("connected");
       reconnectAttemptRef.current = 0;
       // H9: resolve all pending waitForConnection promises
-      for (const resolve of pendingOpenRef.current) {
+      for (const { resolve } of pendingOpenRef.current) {
         resolve();
       }
       pendingOpenRef.current = [];
@@ -127,6 +127,12 @@ export function useWebSocket({
         reconnectTimerRef.current = setTimeout(() => {
           connectImplRef.current();
         }, delay);
+      } else {
+        // No reconnect: reject all pending waitForConnection promises to prevent leaks
+        pendingOpenRef.current.forEach(({ reject }) =>
+          reject(new Error("WebSocket connection failed"))
+        );
+        pendingOpenRef.current = [];
       }
     };
 
@@ -142,6 +148,11 @@ export function useWebSocket({
   const disconnect = useCallback(() => {
     intentionalCloseRef.current = true;
     clearReconnectTimer();
+    // Reject pending waitForConnection promises before closing
+    pendingOpenRef.current.forEach(({ reject }) =>
+      reject(new Error("WebSocket connection closed"))
+    );
+    pendingOpenRef.current = [];
     if (wsRef.current) {
       wsRef.current.close();
       wsRef.current = null;
@@ -163,8 +174,8 @@ export function useWebSocket({
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       return Promise.resolve();
     }
-    return new Promise<void>((resolve) => {
-      pendingOpenRef.current.push(resolve);
+    return new Promise<void>((resolve, reject) => {
+      pendingOpenRef.current.push({ resolve, reject });
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- **HIGH-1**: Fix 3 `errcheck` golangci-lint failures — handle `fmt.Fprintf` and `Conn.Close()` return values
- **HIGH-2**: Fix `DEFAULT_USER_ID = "user-1"` (non-UUID) causing functional bugs — changed to valid UUIDv4 across missions, collection pages, and test fixture
- **MEDIUM-1**: Fix `waitForConnection` Promise leak — reject pending promises when reconnect is exhausted or connection is intentionally closed; add `.catch()` in `connectAndSend` to prevent unhandled rejections

## Verification
- `golangci-lint run ./...` — 0 issues
- `go test -race ./...` — all pass
- `go build -o bin/api ./cmd/api` — success
- `pnpm lint` — no errors
- `pnpm typecheck` — no errors
- `pnpm test` — 10 files, 65 tests pass, 0 unhandled errors

## Test plan
- [ ] CI passes (lint + test + build)
- [ ] Verify health endpoint still returns `{"status":"ok"}`
- [ ] Verify missions page fetches with UUID user ID
- [ ] Verify collection page fetches with UUID user ID
- [ ] Verify WebSocket disconnect/reset does not leak promises